### PR TITLE
Implemented page redirection for logged out users

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
     domains: ['acmucsd.s3.us-west-1.amazonaws.com'],
   },
   poweredByHeader: false,
-  trailingSlash: true,
+  trailingSlash: false,
   basePath: '',
   reactStrictMode: true,
   swcMinify: true,

--- a/src/lib/hoc/withAccessType.ts
+++ b/src/lib/hoc/withAccessType.ts
@@ -24,7 +24,7 @@ export default function withAccessType(
     const originalReturnValue = await gssp(context);
 
     // Save current URL so user can return here after logging in
-    const currentUrl = encodeURIComponent(req.url ?? '/');
+    const currentUrl = encodeURIComponent(req.url ?? config.homeRoute);
 
     const baseRoute = redirectTo ?? config.loginRoute;
     const destinationRoute =
@@ -39,9 +39,10 @@ export default function withAccessType(
 
     // Get user cookie
     const userCookie = CookieService.getServerCookie(CookieType.USER, { req, res });
+    const token = CookieService.getServerCookie(CookieType.ACCESS_TOKEN, { req, res });
 
     // If cookie is misisng, we are not logged in so don't show the current page
-    if (!userCookie) {
+    if (!userCookie || !token) {
       if (currentUrl === config.homeRoute) {
         return {
           redirect: {

--- a/src/lib/hoc/withAccessType.ts
+++ b/src/lib/hoc/withAccessType.ts
@@ -1,11 +1,10 @@
 import config from '@/lib/config';
 import { CookieService } from '@/lib/services';
+import { URL } from '@/lib/types';
 import { PrivateProfile } from '@/lib/types/apiResponses';
 import { CookieType, UserAccessType } from '@/lib/types/enums';
 import * as _ from 'lodash';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
-
-// TODO: We will need a third argument to specify where to send them if they don't have access later so the admin pages can send regular members back to the home page instead of login
 
 /**
  * Redirects to login if user is not logged in and allowed to see the specified page
@@ -15,7 +14,8 @@ import { GetServerSideProps, GetServerSidePropsContext } from 'next';
  */
 export default function withAccessType(
   gssp: GetServerSideProps,
-  validAccessTypes: UserAccessType[]
+  validAccessTypes: UserAccessType[],
+  redirectTo?: URL
 ): GetServerSideProps {
   // Generate a new getServerSideProps function by taking the return value of the original function and appending the user prop onto it if the user cookie exists, otherwise force user to login page
   const modified: GetServerSideProps = async (context: GetServerSidePropsContext) => {
@@ -26,9 +26,13 @@ export default function withAccessType(
     // Save current URL so user can return here after logging in
     const currentUrl = encodeURIComponent(req.url ?? '/');
 
+    const baseRoute = redirectTo ?? config.loginRoute;
+    const destinationRoute =
+      baseRoute === config.loginRoute ? `${baseRoute}?destination=${currentUrl}` : baseRoute;
+
     const safeRedirectToLogin = {
       redirect: {
-        destination: `${config.loginRoute}?destination=${currentUrl}`,
+        destination: destinationRoute,
         permanent: false,
       },
     };


### PR DESCRIPTION
- Removed `trailingSlash` from Next.js redirect urls
- Modified login page to redirect to read query parameters to log users in directly to originally requested page to resolve issue #1 
- Modified `src/lib/hoc/withAccessType` to generate query parameters for users who attempt to reach a page that requires login