### PR TITLE
Completed Reset Password Page

### DIFF
--- a/src/components/auth/SignInFormItem/index.tsx
+++ b/src/components/auth/SignInFormItem/index.tsx
@@ -17,12 +17,13 @@ interface FormItemProps {
   placeholder: string;
   formRegister: UseFormRegisterReturn;
   error: any;
+  inputHeight?: string;
 }
 
 type SignInFormProps = FormItemProps & (InputTypeProps | SelectTypeProps);
 
 const SignInFormItem = (props: SignInFormProps) => {
-  const { icon, placeholder, formRegister, element, error } = props;
+  const { icon, placeholder, formRegister, element, error, inputHeight } = props;
 
   if (element === 'input') {
     const { type } = props;
@@ -35,6 +36,9 @@ const SignInFormItem = (props: SignInFormProps) => {
             required
             type={type}
             placeholder={placeholder}
+            style={{
+              height: inputHeight,
+            }}
             {...formRegister}
           />
         </div>
@@ -50,7 +54,13 @@ const SignInFormItem = (props: SignInFormProps) => {
       <div className={styles.formItem}>
         <div className={styles.formInput}>
           <div className={styles.iconContainer}>{icon}</div>
-          <select {...formRegister} className={styles.selectField}>
+          <select
+            {...formRegister}
+            className={styles.selectField}
+            style={{
+              lineHeight: inputHeight,
+            }}
+          >
             {options.map(value => (
               <option key={value}>{value}</option>
             ))}

--- a/src/components/auth/SignInFormItem/index.tsx
+++ b/src/components/auth/SignInFormItem/index.tsx
@@ -37,7 +37,7 @@ const SignInFormItem = (props: SignInFormProps) => {
             type={type}
             placeholder={placeholder}
             style={{
-              height: inputHeight,
+              lineHeight: inputHeight,
             }}
             {...formRegister}
           />

--- a/src/lib/api/AuthAPI.ts
+++ b/src/lib/api/AuthAPI.ts
@@ -1,9 +1,10 @@
 import { config } from '@/lib';
-import { LoginRequest, UserRegistration } from '@/lib/types/apiRequests';
-import type {
+import { LoginRequest, PasswordResetRequest, UserRegistration } from '@/lib/types/apiRequests';
+import {
   LoginResponse,
   PrivateProfile,
   RegistrationResponse,
+  ResetPasswordResponse,
   SendPasswordResetEmailResponse,
   VerifyEmailResponse,
 } from '@/lib/types/apiResponses';
@@ -55,5 +56,15 @@ export default class AuthAPI {
     const requestUrl = `${config.api.baseUrl}${config.api.endpoints.auth.emailVerification}/${accessCode}`;
 
     await axios.post<VerifyEmailResponse>(requestUrl);
+  }
+
+  /**
+   * Resets password for account by accessCode to new password provided
+   * @param data Request data of the user object with new password and access code
+   */
+  static async resetPassword(data: PasswordResetRequest): Promise<void> {
+    const requestUrl = `${config.api.baseUrl}${config.api.endpoints.auth.resetPassword}/${data.user.code}`;
+
+    await axios.post<ResetPasswordResponse>(requestUrl, data);
   }
 }

--- a/src/lib/managers/AuthManager.ts
+++ b/src/lib/managers/AuthManager.ts
@@ -3,6 +3,7 @@ import { CookieService } from '@/lib/services';
 import { APIHandlerProps } from '@/lib/types';
 import type {
   LoginRequest,
+  PasswordResetRequest,
   SendPasswordResetEmailRequest,
   UserRegistration,
 } from '@/lib/types/apiRequests';
@@ -29,6 +30,10 @@ export default class AuthManager {
     }
   }
 
+  /**
+   * Registers a new user account and provides callback
+   * @param data
+   */
   static async register(data: UserRegistration & APIHandlerProps): Promise<void> {
     const { onSuccessCallback, onFailCallback, ...userRegistration } = data;
     try {
@@ -50,6 +55,21 @@ export default class AuthManager {
 
     try {
       await AuthAPI.sendPasswordResetEmail(email);
+      onSuccessCallback?.();
+    } catch (e: any) {
+      onFailCallback?.(e.response.data.error);
+    }
+  }
+
+  /**
+   * Resets the account's password to the given value and provides callback
+   * @param data
+   */
+  static async resetPassword(data: PasswordResetRequest & APIHandlerProps): Promise<void> {
+    const { user, onSuccessCallback, onFailCallback } = data;
+
+    try {
+      await AuthAPI.resetPassword({ user });
       onSuccessCallback?.();
     } catch (e: any) {
       onFailCallback?.(e.response.data.error);

--- a/src/lib/types/apiRequests.d.ts
+++ b/src/lib/types/apiRequests.d.ts
@@ -16,6 +16,7 @@ export interface LoginRequest {
 }
 
 export interface PasswordChange {
+  code: string;
   newPassword: string;
   confirmPassword: string;
 }

--- a/src/pages/forgot-password.tsx
+++ b/src/pages/forgot-password.tsx
@@ -19,9 +19,7 @@ const ForgotPassword: NextPage = () => {
     formState: { errors },
   } = useForm<SendPasswordResetEmailRequest>();
 
-  const onSubmit: SubmitHandler<SendPasswordResetEmailRequest> = ({
-    email,
-  }: SendPasswordResetEmailRequest) => {
+  const onSubmit: SubmitHandler<SendPasswordResetEmailRequest> = ({ email }) => {
     AuthManager.sendPasswordResetEmail({
       email,
       onSuccessCallback: () => {

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -27,7 +27,7 @@ const LoginPage: NextPage<LoginProps> = ({ destination }) => {
     formState: { errors },
   } = useForm<LoginRequest>();
 
-  const onSubmit: SubmitHandler<LoginRequest> = ({ email, password }: LoginRequest) => {
+  const onSubmit: SubmitHandler<LoginRequest> = ({ email, password }) => {
     AuthManager.login({
       email,
       password,

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -36,7 +36,7 @@ const RegisterPage: NextPage = () => {
 
   const router = useRouter();
 
-  const onSubmit: SubmitHandler<UserRegistration> = (userRegistration: UserRegistration) => {
+  const onSubmit: SubmitHandler<UserRegistration> = userRegistration => {
     AuthManager.register({
       ...userRegistration,
       onSuccessCallback: (user: PrivateProfile) => {
@@ -66,6 +66,7 @@ const RegisterPage: NextPage = () => {
         formRegister={register('firstName', {
           required: 'Required',
         })}
+        inputHeight="1.5rem"
       />
       <SignInFormItem
         icon={<BsPerson />}
@@ -77,6 +78,7 @@ const RegisterPage: NextPage = () => {
         formRegister={register('lastName', {
           required: 'Required',
         })}
+        inputHeight="1.5rem"
       />
       <SignInFormItem
         icon={<AiOutlineMail />}
@@ -89,6 +91,7 @@ const RegisterPage: NextPage = () => {
           required: 'Required',
           validate: str => isEmail(str) || 'Invalid email address',
         })}
+        inputHeight="1.5rem"
       />
       <SignInFormItem
         icon={<VscLock />}
@@ -104,6 +107,7 @@ const RegisterPage: NextPage = () => {
             return true;
           },
         })}
+        inputHeight="1.5rem"
       />
       <SignInFormItem
         icon={<VscLock />}
@@ -121,6 +125,7 @@ const RegisterPage: NextPage = () => {
             return true;
           },
         })}
+        inputHeight="1.5rem"
       />
       <SignInFormItem
         icon={<IoBookOutline />}
@@ -130,6 +135,7 @@ const RegisterPage: NextPage = () => {
         placeholder="Major"
         error={errors.major}
         formRegister={register('major')}
+        inputHeight="1.25rem"
       />
       <SignInFormItem
         icon={<SlGraduation />}
@@ -141,6 +147,7 @@ const RegisterPage: NextPage = () => {
         formRegister={register('graduationYear', {
           valueAsNumber: true,
         })}
+        inputHeight="1.25rem"
       />
       <SignInButton
         type="button"

--- a/src/pages/reset-password/[accessCode].tsx
+++ b/src/pages/reset-password/[accessCode].tsx
@@ -1,0 +1,103 @@
+import { SignInButton, SignInFormItem, SignInTitle } from '@/components/auth';
+import { VerticalForm } from '@/components/common';
+import { config, showToast } from '@/lib';
+import { AuthManager } from '@/lib/managers';
+import { getMessagesFromError } from '@/lib/utils';
+import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { VscLock } from 'react-icons/vsc';
+
+interface ResetPasswordProps {
+  code: string;
+}
+
+interface ResetPasswordForm {
+  newPassword: string;
+  confirmPassword: string;
+}
+
+const ResetPasswordPage = ({ code }: ResetPasswordProps) => {
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    formState: { errors },
+  } = useForm<ResetPasswordForm>();
+
+  const onSubmit: SubmitHandler<ResetPasswordForm> = ({ newPassword, confirmPassword }) => {
+    AuthManager.resetPassword({
+      user: {
+        newPassword,
+        confirmPassword,
+        code,
+      },
+      onSuccessCallback: () => {
+        showToast('Password successfully updated!');
+        router.push(config.loginRoute);
+      },
+      onFailCallback: error => {
+        showToast('Unable to reset password', getMessagesFromError(error)[0]);
+      },
+    });
+  };
+
+  return (
+    <VerticalForm onEnterPress={handleSubmit(onSubmit)}>
+      <SignInTitle text="Reset Password" />
+      <SignInFormItem
+        icon={<VscLock />}
+        type="password"
+        element="input"
+        name="password"
+        placeholder="Password"
+        formRegister={register('newPassword', {
+          required: 'Required',
+          validate: value => {
+            if (!value) return 'Required';
+            if (value.length <= 8) return 'Password must be longer than 8 characters';
+            return true;
+          },
+        })}
+        error={errors.newPassword}
+      />
+      <SignInFormItem
+        icon={<VscLock />}
+        type="password"
+        element="input"
+        name="confirmPassword"
+        placeholder="Confirm Password"
+        formRegister={register('confirmPassword', {
+          required: 'Required',
+          validate: value => {
+            if (!value) return 'Required';
+            if (value.length <= 8) return 'Password must be longer than 8 characters';
+            const newPassword = getValues('newPassword');
+            if (value !== newPassword) return 'Passwords Must Match';
+            return true;
+          },
+        })}
+        error={errors.confirmPassword}
+      />
+      <SignInButton
+        type="button"
+        display="button1"
+        text="Submit"
+        onClick={handleSubmit(onSubmit)}
+      />
+    </VerticalForm>
+  );
+};
+
+export default ResetPasswordPage;
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  const code = params?.accessCode as string;
+  return {
+    props: {
+      code,
+    },
+  };
+};


### PR DESCRIPTION
- Completed reset password page to read access code from URL param and post to API with form data containing new password.
- Modified react-hook-form onSubmit type slightly for simplicity.
- Restyled register page to take up less vertical space

Closes #4 

I don't think it's possible to test a valid use case of this page in Cypress since we need to fetch the access code from a genuine email sent to the user so I've included screenshots of every edge case.


### Failing Validation on Both Fields
![Screenshot 2023-04-07 at 1 07 01 AM](https://user-images.githubusercontent.com/33165426/230570758-b4dd40e4-4e3c-4d56-856b-bd0dfc229a90.jpg)

### Mismatched Passwords
![Screenshot 2023-04-07 at 1 07 17 AM](https://user-images.githubusercontent.com/33165426/230570824-c17e3246-80f1-45e7-a191-342d1b3cb4a1.jpg)

### Valid Usage Response
 Redirect to login with toast
![Screenshot 2023-04-07 at 1 07 25 AM](https://user-images.githubusercontent.com/33165426/230570882-ccc1339a-4d56-4633-af3a-bdab48d4fca1.jpg)

### Invalid URL param accessCode
![Screenshot 2023-04-07 at 1 10 22 AM](https://user-images.githubusercontent.com/33165426/230570940-5faefe4c-6efa-4412-92bf-cc1a42a20e88.jpg)

