### PR TITLE
Optimize Images

### DIFF
--- a/src/components/layout/Navbar/index.tsx
+++ b/src/components/layout/Navbar/index.tsx
@@ -1,5 +1,6 @@
 import { config } from '@/lib';
 import type { PrivateProfile } from '@/lib/types/apiResponses';
+import LightModeLogo from '@/public/assets/acm-logos/general/light-mode.png';
 import ProfileIcon from '@/public/assets/icons/profile-icon.svg';
 import ShopIcon from '@/public/assets/icons/shop-icon.svg';
 import Image from 'next/image';
@@ -17,12 +18,7 @@ const Navbar = ({ user }: NavbarProps) => {
       <header className={styles.header}>
         <div className={styles.content}>
           <Link href={config.homeRoute} className={styles.navLeft}>
-            <Image
-              src="/assets/acm-logos/general/light-mode.png"
-              alt="ACM General Logo"
-              width={48}
-              height={48}
-            />
+            <Image src={LightModeLogo} alt="ACM General Logo" width={48} height={48} />
             <span className={styles.headerTitle}>Membership Portal</span>
           </Link>
           <DarkModeToggle />
@@ -35,12 +31,7 @@ const Navbar = ({ user }: NavbarProps) => {
     <header className={styles.header}>
       <div className={styles.content}>
         <Link href={config.homeRoute} className={styles.icon}>
-          <Image
-            src="/assets/acm-logos/general/light-mode.png"
-            alt="ACM General Logo"
-            width={48}
-            height={48}
-          />
+          <Image src={LightModeLogo} alt="ACM General Logo" width={48} height={48} />
         </Link>
         <nav className={styles.portalLinks}>
           <Link href="/">Events</Link>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,12 +1,13 @@
 import { SignInButton } from '@/components/auth';
 import { VerticalForm } from '@/components/common';
+import Cat404 from '@/public/assets/graphics/cat404.png';
 import styles from '@/styles/pages/404.module.scss';
 import Image from 'next/image';
 
 const PageNotFound = () => (
   <VerticalForm style={{ alignItems: 'center' }}>
     <h1 className={styles.header}>Whoops, we entered up on the wrong page!</h1>
-    <Image src="/assets/graphics/cat404.png" width={256} height={256} alt="Sad Cat" />
+    <Image src={Cat404} width={256} height={256} alt="Sad Cat" />
     <SignInButton type="link" display="button1" href="/" text="Return to Home" />
   </VerticalForm>
 );


### PR DESCRIPTION
# Description

Minor 10% performance boost for the website (removes a 20ms load time out of an average page ~200ms load)

If you open the portal right now on subsequent loads after your first visit, all assets are cached correctly except images which are fetched every single time.

**Current**
![Screenshot 2023-04-12 at 8 49 09 PM](https://user-images.githubusercontent.com/33165426/231671632-f5c6fe4e-f2b8-424b-9821-287e3e6fbb58.jpg)

This change allows for proper catching of images

**New**
![Screenshot 2023-04-12 at 8 48 42 PM](https://user-images.githubusercontent.com/33165426/231671727-0a2467dc-16e8-4987-ba51-38108f0cb46b.jpg)

I misunderstoof the library and thought that and relative path image src attributes would be treated as local images but apparently any relative or absolute links are treated as remote resources. We have to use the specific import syntax seen in this PR to let the codebase know that the file is a local image to allow for proper optimizations + caching. 


See [Image Optimization](https://nextjs.org/docs/basic-features/image-optimization#local-images) in the Next.js documentation.

## Changes

- Changed all image src tags

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] locally on mobile - use https://ngrok.io to get a copy on a mobile device
- [x] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have run and passed all new and existing Cypress tests. Add screenshots below.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented my code's `src/lib` functions and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Cypress testing suite passing successfully.

If you made any visual changes to the website, please include relevant screenshots below.
