### PR TITLE
Optimize Fonts

### DIFF
--- a/src/components/auth/SignInButton/style.module.scss
+++ b/src/components/auth/SignInButton/style.module.scss
@@ -1,6 +1,5 @@
 .link {
   color: var(--theme-text-on-background-1);
-  font-family: 'DM Sans', sans-serif;
   font-size: 16px;
   font-weight: 400;
   line-height: 150%;
@@ -19,7 +18,6 @@
   color: var(--theme-background);
   display: flex;
 
-  font-family: 'DM Sans', sans-serif;
   font-size: 20px;
   font-weight: 700;
   height: 2.25rem;
@@ -42,7 +40,6 @@
   color: var(--theme-background);
   display: flex;
 
-  font-family: 'DM Sans', sans-serif;
   font-size: 20px;
   font-weight: 700;
   height: 2.25rem;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,19 +11,30 @@ import { CookieType } from '@/lib/types/enums';
 import { NextPageContext } from 'next';
 import { ThemeProvider } from 'next-themes';
 import type { AppProps } from 'next/app';
+// eslint-disable-next-line camelcase
+import { DM_Sans } from 'next/font/google';
 import { ToastContainer } from 'react-toastify';
 
 interface InitialPropInterface {
   user: PrivateProfile;
 }
+const dmSans = DM_Sans({ subsets: ['latin'], weight: ['400', '500', '700'] });
+
 export default function MyApp({ Component, pageProps }: AppProps<InitialPropInterface>) {
   return (
-    <ThemeProvider>
-      <ToastContainer />
-      <PageLayout user={pageProps?.user}>
-        <Component {...pageProps} />
-      </PageLayout>
-    </ThemeProvider>
+    <>
+      <style jsx global>{`
+        * {
+          font-family: ${dmSans.style.fontFamily}, sans-serif;
+        }
+      `}</style>
+      <ThemeProvider>
+        <ToastContainer />
+        <PageLayout user={pageProps?.user}>
+          <Component {...pageProps} />
+        </PageLayout>
+      </ThemeProvider>
+    </>
   );
 }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,14 +11,13 @@ import { CookieType } from '@/lib/types/enums';
 import { NextPageContext } from 'next';
 import { ThemeProvider } from 'next-themes';
 import type { AppProps } from 'next/app';
-// eslint-disable-next-line camelcase
-import { DM_Sans } from 'next/font/google';
+import { DM_Sans as DMSans } from 'next/font/google';
 import { ToastContainer } from 'react-toastify';
 
 interface InitialPropInterface {
   user: PrivateProfile;
 }
-const dmSans = DM_Sans({ subsets: ['latin'], weight: ['400', '500', '700'] });
+const dmSans = DMSans({ subsets: ['latin'], weight: ['400', '500', '700'] });
 
 export default function MyApp({ Component, pageProps }: AppProps<InitialPropInterface>) {
   return (

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,5 +1,4 @@
 @use './vars.scss' as vars;
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap');
 
 html,
 body {
@@ -7,10 +6,6 @@ body {
   line-height: 1.5;
   margin: 0;
   padding: 0;
-}
-
-* {
-  font-family: 'DM Sans', sans-serif;
 }
 
 main {


### PR DESCRIPTION
# Description

On initial or full page loads of the Membership Portal (disable caching), fetching font resources files for DM Sans takes 

`579ms` out of `720ms` for the total page load (80% of page load time)
![Screenshot 2023-04-12 at 11 49 45 PM](https://user-images.githubusercontent.com/33165426/231677774-a4c0e559-80ac-4d26-b912-f6fca56b1e2d.jpg)

`294ms` out of `343ms` for the total page load (85% of page load time)
![Screenshot 2023-04-12 at 11 50 21 PM](https://user-images.githubusercontent.com/33165426/231677797-f5160da0-2331-4c0d-bd7a-fb76b48fe44c.jpg)

The solution to this significant data fetch is to self-host our fonts in the repo and define the font-face "DM Sans" to pull from the file that stores the font-face configuration. Next.js offers a better solution than doing it from scratch in only a few lines of code that offers the exact same solution but we don't actually have to perform this full setup - it will automatically happen at build time when the project is compiled.

With the change proposed in this PR, font loading now takes `~60ms` instead of `~500ms` with a total page load time of under `200ms` reducing the load time by nearly 90%.

See [Font Optimization](https://nextjs.org/docs/basic-features/font-optimization) for official Next.js documentation.

## Changes

- Switches to Next.js recommended font import method.

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [ ] locally on Desktop.
- [ ] locally on mobile - use https://ngrok.io to get a copy on a mobile device
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have run and passed all new and existing Cypress tests. Add screenshots below.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] I have documented my code's `src/lib` functions and commented hard to understand areas
      anywhere else.
- [ ] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Cypress testing suite passing successfully.

If you made any visual changes to the website, please include relevant screenshots below.
