### PR TITLE
Leaderboard rows

### DIFF
--- a/src/components/layout/PageLayout/style.module.scss
+++ b/src/components/layout/PageLayout/style.module.scss
@@ -2,6 +2,5 @@
 
 .content {
   margin-top: vars.$header-height;
-  overflow-y: scroll;
   padding: 2rem;
 }

--- a/src/components/layout/PageLayout/style.module.scss
+++ b/src/components/layout/PageLayout/style.module.scss
@@ -2,5 +2,6 @@
 
 .content {
   margin-top: vars.$header-height;
+  overflow: auto;
   padding: 2rem;
 }

--- a/src/components/leaderboard/LeaderboardRow/index.tsx
+++ b/src/components/leaderboard/LeaderboardRow/index.tsx
@@ -12,11 +12,17 @@ interface LeaderboardRowProps {
 const LeaderboardRow = ({ position, rank, name, points, image }: LeaderboardRowProps) => {
   return (
     <div className={styles.row} data-style={position % 2 === 0 ? 'even' : 'odd'}>
-      <span>{position}</span>
-      <Image src={image} width={36} height={36} alt="User" />
-      <span>{name}</span>
-      <span>{rank}</span>
-      <span>{points} points</span>
+      <span className={styles.position}>{position}</span>
+      <Image
+        src={image}
+        width={36}
+        height={36}
+        alt={`Profile picture for ${name}`}
+        className={styles.profilePicture}
+      />
+      <span className={styles.name}>{name}</span>
+      <span className={styles.rank}>{rank}</span>
+      <span className={styles.points}>{points} points</span>
     </div>
   );
 };

--- a/src/components/leaderboard/LeaderboardRow/index.tsx
+++ b/src/components/leaderboard/LeaderboardRow/index.tsx
@@ -1,0 +1,24 @@
+import Image from 'next/image';
+import styles from './style.module.scss';
+
+interface LeaderboardRowProps {
+  position: number;
+  rank: string;
+  name: string;
+  points: number;
+  image: string;
+}
+
+const LeaderboardRow = ({ position, rank, name, points, image }: LeaderboardRowProps) => {
+  return (
+    <div className={styles.row} data-style={position % 2 === 0 ? 'even' : 'odd'}>
+      <span>{position}</span>
+      <Image src={image} width={36} height={36} alt="User" />
+      <span>{name}</span>
+      <span>{rank}</span>
+      <span>{points} points</span>
+    </div>
+  );
+};
+
+export default LeaderboardRow;

--- a/src/components/leaderboard/LeaderboardRow/index.tsx
+++ b/src/components/leaderboard/LeaderboardRow/index.tsx
@@ -17,6 +17,7 @@ const LeaderboardRow = ({ position, rank, name, points, image }: LeaderboardRowP
         src={image}
         width={36}
         height={36}
+        quality={10}
         alt={`Profile picture for ${name}`}
         className={styles.profilePicture}
       />

--- a/src/components/leaderboard/LeaderboardRow/index.tsx
+++ b/src/components/leaderboard/LeaderboardRow/index.tsx
@@ -20,8 +20,10 @@ const LeaderboardRow = ({ position, rank, name, points, image }: LeaderboardRowP
         alt={`Profile picture for ${name}`}
         className={styles.profilePicture}
       />
-      <span className={styles.name}>{name}</span>
-      <span className={styles.rank}>{rank}</span>
+      <div className={styles.nameRank}>
+        <span className={styles.name}>{name}</span>
+        <span className={styles.rank}>{rank}</span>
+      </div>
       <span className={styles.points}>{points} points</span>
     </div>
   );

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -61,3 +61,14 @@
     text-align: left;
   }
 }
+
+@media (max-width: 450px) {
+  .row {
+    gap: 16px;
+    padding: 0 24px;
+  }
+
+  .position {
+    margin-right: -8px;
+  }
+}

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -4,66 +4,60 @@
   align-items: center;
   background-color: var(--theme-surface-1);
   display: grid;
-  font-size: 15px;
-  gap: 32px;
+  font-size: 0.9375rem; // 15px per Figma
+  gap: 2rem;
   grid-template-columns: auto auto 2fr 1fr;
-  height: 64px;
-  padding: 0 32px;
+  height: 4rem;
+  padding: 0 2rem;
+
+  @media (max-width: vars.$breakpoint-md) {
+    gap: 1rem;
+    grid-template-columns: auto auto 1fr auto;
+    padding: 0 1.5rem;
+  }
 
   &[data-style='odd'] {
     background-color: var(--theme-background);
   }
-}
 
-.position {
-  font-size: 20px;
-  font-weight: bold;
-  width: 40px;
-}
+  .position {
+    font-size: 1.25rem;
+    font-weight: bold;
+    width: 2.5rem;
+  }
 
-.profilePicture {
-  border-radius: 50%;
-}
-
-.nameRank {
-  display: grid;
-  gap: 32px;
-  grid-template-columns: 1fr 1fr;
-}
-
-.name,
-.points {
-  font-weight: 500;
-}
-
-.rank {
-  color: var(--theme-text-on-surface-1);
-  opacity: 0.5;
-  text-align: center;
-}
-
-.points {
-  text-align: right;
-}
-
-@media (max-width: vars.$breakpoint-md) {
-  .row {
-    gap: 16px;
-    grid-template-columns: auto auto 1fr auto;
-    padding: 0 24px;
+  .profilePicture {
+    border-radius: 50%;
   }
 
   .nameRank {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5em;
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: 1fr 1fr;
+
+    @media (max-width: vars.$breakpoint-md) {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5em;
+    }
+
+    .name {
+      font-weight: 500;
+    }
+
+    .rank {
+      color: var(--theme-text-on-surface-1);
+      opacity: 0.5;
+      text-align: center;
+
+      @media (max-width: vars.$breakpoint-md) {
+        text-align: left;
+      }
+    }
   }
 
-  .position {
-    margin-right: -8px;
-  }
-
-  .rank {
-    text-align: left;
+  .points {
+    font-weight: 500;
+    text-align: right;
   }
 }

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -8,12 +8,13 @@
   gap: 2rem;
   grid-template-columns: auto auto 2fr 1fr;
   height: 4rem;
-  padding: 0 2rem;
+  padding-left: 0.5rem;
+  padding-right: 2rem;
 
   @media (max-width: vars.$breakpoint-md) {
     gap: 1rem;
     grid-template-columns: auto auto 1fr auto;
-    padding: 0 1.5rem;
+    padding-right: 1.5rem;
   }
 
   &[data-style='odd'] {
@@ -23,6 +24,7 @@
   .position {
     font-size: 1.25rem;
     font-weight: bold;
+    text-align: right;
     width: 2.5rem;
   }
 

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -1,0 +1,14 @@
+@use 'src/styles/vars.scss' as vars;
+
+.row {
+  align-items: center center;
+  background-color: var(--theme-surface-1);
+  display: grid;
+  grid-template-columns: 1fr 1fr 3fr 3fr 3fr;
+  justify-content: space-evenly;
+  padding: 2px;
+
+  &[data-style='odd'] {
+    background-color: var(--theme-background);
+  }
+}

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -2,13 +2,46 @@
 
 .row {
   align-items: center center;
+  align-items: center;
   background-color: var(--theme-surface-1);
-  display: grid;
-  grid-template-columns: 1fr 1fr 3fr 3fr 3fr;
-  justify-content: space-evenly;
-  padding: 2px;
+  display: flex;
+  font-size: 15px;
+  gap: 32px;
+  height: 64px;
+  padding: 8px 32px;
 
   &[data-style='odd'] {
     background-color: var(--theme-background);
   }
+}
+
+.position {
+  font-size: 20px;
+  font-weight: bold;
+  width: 40px;
+}
+
+.profilePicture {
+  border-radius: 50%;
+}
+
+.name,
+.rank,
+.points {
+  flex: 1 0 0;
+  text-align: center;
+}
+
+.name,
+.points {
+  font-weight: 500;
+}
+
+.rank {
+  color: var(--theme-text-on-surface-1);
+  opacity: 0.5;
+}
+
+.points {
+  text-align: right;
 }

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -7,7 +7,7 @@
   gap: 2rem;
   grid-template-columns: auto auto 2fr 1fr;
   min-height: 4rem;
-  padding-left: 0.5rem;
+  padding: 0.5rem;
   padding-right: 2rem;
 
   @media (max-width: vars.$breakpoint-md) {

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -4,7 +4,6 @@
   align-items: center;
   background-color: var(--theme-surface-1);
   display: grid;
-  font-size: 0.9375rem; // 15px per Figma
   gap: 2rem;
   grid-template-columns: auto auto 2fr 1fr;
   height: 4rem;

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -6,7 +6,7 @@
   display: grid;
   gap: 2rem;
   grid-template-columns: auto auto 2fr 1fr;
-  height: 4rem;
+  min-height: 4rem;
   padding-left: 0.5rem;
   padding-right: 2rem;
 

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -1,14 +1,14 @@
 @use 'src/styles/vars.scss' as vars;
 
 .row {
-  align-items: center center;
   align-items: center;
   background-color: var(--theme-surface-1);
-  display: flex;
+  display: grid;
   font-size: 15px;
   gap: 32px;
+  grid-template-columns: auto auto 2fr 1fr;
   height: 64px;
-  padding: 8px 32px;
+  padding: 0 32px;
 
   &[data-style='odd'] {
     background-color: var(--theme-background);
@@ -25,11 +25,10 @@
   border-radius: 50%;
 }
 
-.name,
-.rank,
-.points {
-  flex: 1 0 0;
-  text-align: center;
+.nameRank {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: 1fr 1fr;
 }
 
 .name,
@@ -40,8 +39,25 @@
 .rank {
   color: var(--theme-text-on-surface-1);
   opacity: 0.5;
+  text-align: center;
 }
 
 .points {
   text-align: right;
+}
+
+@media (max-width: 800px) {
+  .row {
+    grid-template-columns: auto auto 1fr auto;
+  }
+
+  .nameRank {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+  }
+
+  .rank {
+    text-align: left;
+  }
 }

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss
@@ -46,9 +46,11 @@
   text-align: right;
 }
 
-@media (max-width: 800px) {
+@media (max-width: vars.$breakpoint-md) {
   .row {
+    gap: 16px;
     grid-template-columns: auto auto 1fr auto;
+    padding: 0 24px;
   }
 
   .nameRank {
@@ -57,18 +59,11 @@
     gap: 0.5em;
   }
 
-  .rank {
-    text-align: left;
-  }
-}
-
-@media (max-width: 450px) {
-  .row {
-    gap: 16px;
-    padding: 0 24px;
-  }
-
   .position {
     margin-right: -8px;
+  }
+
+  .rank {
+    text-align: left;
   }
 }

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss.d.ts
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss.d.ts
@@ -1,5 +1,6 @@
 export type Styles = {
   name: string;
+  nameRank: string;
   points: string;
   position: string;
   profilePicture: string;

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss.d.ts
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss.d.ts
@@ -1,8 +1,5 @@
 export type Styles = {
-  container: string;
-  header: string;
-  leaderboard: string;
-  topThreeContainer: string;
+  row: string;
 };
 
 export type ClassNames = keyof Styles;

--- a/src/components/leaderboard/LeaderboardRow/style.module.scss.d.ts
+++ b/src/components/leaderboard/LeaderboardRow/style.module.scss.d.ts
@@ -1,4 +1,9 @@
 export type Styles = {
+  name: string;
+  points: string;
+  position: string;
+  profilePicture: string;
+  rank: string;
   row: string;
 };
 

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -1,2 +1,3 @@
 /* eslint-disable import/prefer-default-export */
+export { default as LeaderboardRow } from './LeaderboardRow';
 export { default as TopThreeCard } from './TopThreeCard';

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -1,4 +1,5 @@
 import { TopThreeCard } from '@/components/leaderboard';
+import LeaderboardRow from '@/components/leaderboard/LeaderboardRow';
 import { LeaderboardAPI } from '@/lib/api';
 import withAccessType from '@/lib/hoc/withAccessType';
 import { CookieService, PermissionService } from '@/lib/services';
@@ -7,7 +8,6 @@ import { CookieType } from '@/lib/types/enums';
 import { getProfilePicture, getUserRank } from '@/lib/utils';
 import styles from '@/styles/pages/leaderboard.module.scss';
 import { GetServerSideProps } from 'next';
-import Image from 'next/image';
 
 interface LeaderboardProps {
   leaderboard: PublicProfile[];
@@ -43,19 +43,14 @@ const LeaderboardPage = (props: LeaderboardProps) => {
       <div className={styles.leaderboard}>
         {leaderboardRows.map((user, index) => {
           return (
-            <div
+            <LeaderboardRow
               key={user.uuid}
-              className={styles.row}
-              data-style={index % 2 === 0 ? 'even' : 'odd'}
-            >
-              <span>{index + 4}</span>
-              <Image src={getProfilePicture(user)} width={36} height={36} alt="User" />
-              <span>
-                {user.firstName} {user.lastName}
-              </span>
-              <span>{getUserRank(user)}</span>
-              <span>{user.points} points</span>
-            </div>
+              position={index + 4}
+              rank={getUserRank(user)}
+              name={`${user.firstName} ${user.lastName}`}
+              points={user.points}
+              image={getProfilePicture(user)}
+            />
           );
         })}
       </div>

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -1,5 +1,4 @@
-import { TopThreeCard } from '@/components/leaderboard';
-import LeaderboardRow from '@/components/leaderboard/LeaderboardRow';
+import { LeaderboardRow, TopThreeCard } from '@/components/leaderboard';
 import { LeaderboardAPI } from '@/lib/api';
 import withAccessType from '@/lib/hoc/withAccessType';
 import { CookieService, PermissionService } from '@/lib/services';

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -23,7 +23,7 @@ const LeaderboardPage = (props: LeaderboardProps) => {
   return (
     <div className={styles.container}>
       <div className={styles.header}>
-        <h1>Leaderboard</h1>
+        <h1 className={styles.heading}>Leaderboard</h1>
         <select name="timeOptions" id="timeOptions">
           <option>All Time</option>
         </select>

--- a/src/styles/pages/leaderboard.module.scss
+++ b/src/styles/pages/leaderboard.module.scss
@@ -1,19 +1,31 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 2rem;
   margin: 0 auto;
   max-width: 960px;
 
   .header {
+    align-items: center;
     display: flex;
     justify-content: space-between;
   }
 
+  .heading {
+    font-size: 24px;
+    letter-spacing: 1%;
+    line-height: 32px;
+  }
+
   .topThreeContainer {
     display: flex;
+    flex-wrap: wrap;
     gap: 1rem;
     justify-content: space-between;
+
+    @media (max-width: 906px) {
+      justify-content: center;
+    }
   }
 
   .leaderboard {

--- a/src/styles/pages/leaderboard.module.scss
+++ b/src/styles/pages/leaderboard.module.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   gap: 2rem;
   margin: 0 auto;
-  max-width: 960px;
+  max-width: 60rem;
 
   .header {
     align-items: center;
@@ -14,9 +14,9 @@
   }
 
   .heading {
-    font-size: 24px;
+    font-size: 1.5rem;
     letter-spacing: 1%;
-    line-height: 32px;
+    line-height: 2rem;
   }
 
   .topThreeContainer {
@@ -31,7 +31,7 @@
   }
 
   .leaderboard {
-    border-radius: 12px;
+    border-radius: 0.75rem;
     display: flex;
     flex-direction: column;
     overflow: hidden;

--- a/src/styles/pages/leaderboard.module.scss
+++ b/src/styles/pages/leaderboard.module.scss
@@ -33,5 +33,9 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    @media (max-width: 600px) {
+      border-radius: 0;
+      margin: 0 -2rem;
+    }
   }
 }

--- a/src/styles/pages/leaderboard.module.scss
+++ b/src/styles/pages/leaderboard.module.scss
@@ -21,18 +21,5 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
-
-    .row {
-      align-items: center center;
-      background-color: var(--theme-surface-1);
-      display: grid;
-      grid-template-columns: 1fr 1fr 3fr 3fr 3fr;
-      justify-content: space-evenly;
-      padding: 2px;
-
-      &[data-style='odd'] {
-        background-color: var(--theme-background);
-      }
-    }
   }
 }

--- a/src/styles/pages/leaderboard.module.scss
+++ b/src/styles/pages/leaderboard.module.scss
@@ -1,3 +1,5 @@
+@use 'src/styles/vars.scss' as vars;
+
 .container {
   display: flex;
   flex-direction: column;
@@ -23,7 +25,7 @@
     gap: 1rem;
     justify-content: space-between;
 
-    @media (max-width: 906px) {
+    @media (max-width: vars.$breakpoint-lg) {
       justify-content: center;
     }
   }
@@ -33,7 +35,8 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    @media (max-width: 600px) {
+
+    @media (max-width: vars.$breakpoint-sm) {
       border-radius: 0;
       margin: 0 -2rem;
     }

--- a/src/styles/pages/leaderboard.module.scss.d.ts
+++ b/src/styles/pages/leaderboard.module.scss.d.ts
@@ -1,6 +1,7 @@
 export type Styles = {
   container: string;
   header: string;
+  heading: string;
   leaderboard: string;
   topThreeContainer: string;
 };


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

Closes **#41**. (If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak).

# Description

What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context.

The changes are listed below

## Changes

- Moves leaderboard row to its own component (per #41)

  The props for this component mirror `TopThreeCard`. I personally would've made the component just take a `PublicProfile` object, but taking each property individually would probably be better for creating a placeholder while loading, for example.

- Styles leaderboard row according to design (per #41)

  One deviation I made from the design is left-aligning user names, which I think looks nicer.

  I also had to deviate from the design for the mobile leaderboard so it doesn't look as crammed on mobile. I removed the margins on the sides (so it's flush with the edge of the screen) as well as reducing the spacing. This is what it looked like before the changes:

  <img src="https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/00b75421-eaa6-4868-abce-ca8c472b07ae" alt="Mobile view of design's leaderboard row" height="300">

- Adjusted styles in rest of leaderboard page to match design

- On mobile, the top three leaderboard items wrap like they do on the current leaderboard site. I've added a gap between the top two, which isn't present on the current site:

  Old members site | This PR
  --- | ---
  ![old members leaderboard](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/4e1945c3-bbc7-45c8-a137-d4c747dd4a81) | ![leaderboard in this PR](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/ff5c9228-c32b-4b25-bfe4-40f7e47f7f98)

- Not related to the leaderboard page, but I removed a double scrollbar that appears on the page content. I'm guessing because many of the developers are on Macs, they didn't notice this, but Windows scrollbars are thick 😩
  
  <img src="https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/ee7602c6-a84c-4c63-b70f-09f8d35f8cc7" alt="Double scrollbars" height="300">

# Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [x] locally on mobile - use https://ngrok.io to get a copy on a mobile device
- [x] on the live deployment preview on Desktop.
- [x] on the live deployment preview on Mobile.
- [x] I have run and passed all new and existing Cypress tests. Add screenshots below.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented my code's `src/lib` functions and commented hard to understand areas
      anywhere else. *(Vacuously true)*
- [x] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Cypress testing suite passing successfully.

![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/2decbfab-96ca-40c0-99e7-6c140ed088c5)

If you made any visual changes to the website, please include relevant screenshots below.

Desktop | Mobile
--- | ---
![Desktop leaderboard](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/b322780a-9153-41f9-a2ed-9da1da68e7f2) | ![Mobile leaderboard](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/398c5e65-1844-4fc1-919e-d24c65f956e2)
