### PR TITLE
Temporary slice events to save over-rendering, split events into curr…

### DIFF
--- a/src/components/events/EventDisplay/index.tsx
+++ b/src/components/events/EventDisplay/index.tsx
@@ -8,7 +8,7 @@ interface EventDisplayProps {
 }
 
 const EventDisplay = ({ events, attendances }: EventDisplayProps) => {
-  const displayedEvents = events.slice(0, Math.min(20, events.length));
+  const displayedEvents = events.slice(0, 20);
   return (
     <div className={styles.container}>
       {displayedEvents.map(event => (

--- a/src/components/events/EventDisplay/index.tsx
+++ b/src/components/events/EventDisplay/index.tsx
@@ -8,7 +8,7 @@ interface EventDisplayProps {
 }
 
 const EventDisplay = ({ events, attendances }: EventDisplayProps) => {
-  const displayedEvents = events;
+  const displayedEvents = events.slice(0, Math.min(20, events.length));
   return (
     <div className={styles.container}>
       {displayedEvents.map(event => (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -41,9 +41,21 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
   const attendances = await EventAPI.getAttendancesForUser(authToken);
 
   const now = new Date();
-  const pastEvents = events.filter(e => new Date(e.end) < now);
-  const futureEvents = events.filter(e => new Date(e.start) > now);
-  const currentEvents = events.filter(e => new Date(e.start) <= now && new Date(e.end) >= now);
+  const pastEvents: PublicEvent[] = [];
+  const futureEvents: PublicEvent[] = [];
+  const currentEvents: PublicEvent[] = [];
+
+  events.forEach(e => {
+    const start = new Date(e.start);
+    const end = new Date(e.end);
+    if (end < now) {
+      pastEvents.push(e);
+    } else if (start > now) {
+      futureEvents.push(e);
+    } else {
+      currentEvents.push(e);
+    }
+  });
 
   return { props: { pastEvents, futureEvents, currentEvents, attendances } };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,16 +8,27 @@ import { GetServerSideProps } from 'next';
 
 interface HomePageProps {
   user: PrivateProfile;
-  events: PublicEvent[];
+  pastEvents: PublicEvent[];
+  futureEvents: PublicEvent[];
+  currentEvents: PublicEvent[];
   attendances: PublicAttendance[];
 }
 
-const PortalHomePage = ({ user, events, attendances }: HomePageProps) => {
+const PortalHomePage = ({
+  user,
+  pastEvents,
+  futureEvents,
+  currentEvents,
+  attendances,
+}: HomePageProps) => {
   return (
     <div>
       <h1>Portal Home Page</h1>
       <pre>User Info: {JSON.stringify(user, null, 2)}</pre>
-      <EventDisplay events={events} attendances={attendances} />
+
+      <EventDisplay events={currentEvents} attendances={attendances} />
+      <EventDisplay events={futureEvents} attendances={attendances} />
+      <EventDisplay events={pastEvents} attendances={attendances} />
     </div>
   );
 };
@@ -29,7 +40,12 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
   const events = await EventAPI.getAllEvents();
   const attendances = await EventAPI.getAttendancesForUser(authToken);
 
-  return { props: { events, attendances } };
+  const now = new Date();
+  const pastEvents = events.filter(e => new Date(e.end) < now);
+  const futureEvents = events.filter(e => new Date(e.start) > now);
+  const currentEvents = events.filter(e => new Date(e.start) <= now && new Date(e.end) >= now);
+
+  return { props: { pastEvents, futureEvents, currentEvents, attendances } };
 };
 
 export const getServerSideProps = withAccessType(


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Description

- So I noticed on prod that there are way more events and our current display is rendering them all, making the page really laggy.
- As a temporary fix, I'm slicing it to a max of 20 events on the page
- I also added some extra code to split events into live, past, and future, which will be useful down the line
- This can be considered some scaffolding code for the dashboard page down the line.

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] locally on mobile - use https://ngrok.io to get a copy on a mobile device
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have run and passed all new and existing Cypress tests. Add screenshots below.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] I have documented my code's `src/lib` functions and commented hard to understand areas
      anywhere else.
- [ ] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Cypress testing suite passing successfully.

If you made any visual changes to the website, please include relevant screenshots below.
