### PR TITLE
Events Page/Card: Fix some stuff

### DIFF
--- a/src/components/events/EventCard/index.tsx
+++ b/src/components/events/EventCard/index.tsx
@@ -11,9 +11,10 @@ interface EventCardProps {
   event: PublicEvent;
   attended: boolean;
   className?: string;
+  showYear?: boolean;
 }
 
-const EventCard = ({ event, attended, className }: EventCardProps) => {
+const EventCard = ({ event, attended, className, showYear }: EventCardProps) => {
   const { cover, title, start, end, location } = event;
   const [expanded, setExpanded] = useState(false);
 
@@ -57,7 +58,7 @@ const EventCard = ({ event, attended, className }: EventCardProps) => {
                 style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
                 suppressHydrationWarning
               >
-                {formatEventDate(start, end)}
+                {formatEventDate(start, end, showYear)}
               </Typography>
               <Typography
                 variant="body/small"

--- a/src/components/events/EventCard/style.module.scss
+++ b/src/components/events/EventCard/style.module.scss
@@ -16,7 +16,7 @@
   }
 
   .image {
-    aspect-ratio: 1.778;
+    aspect-ratio: 1920 / 1080;
     flex-shrink: 0;
     overflow: none;
     position: relative;

--- a/src/components/events/EventDisplay/index.tsx
+++ b/src/components/events/EventDisplay/index.tsx
@@ -19,6 +19,7 @@ const EventDisplay = ({ events, attendances }: EventDisplayProps) => {
           key={event.uuid}
           event={event}
           attended={attendances.some(a => a.event.uuid === event.uuid)}
+          showYear
         />
       ))}
     </div>

--- a/src/components/events/EventModal/style.module.scss
+++ b/src/components/events/EventModal/style.module.scss
@@ -48,7 +48,7 @@
     transition: transform 0.2s;
 
     .image {
-      aspect-ratio: 1.778;
+      aspect-ratio: 1920 / 1080;
       flex-shrink: 0;
       overflow: hidden;
       position: relative;

--- a/src/components/events/EventModal/style.module.scss
+++ b/src/components/events/EventModal/style.module.scss
@@ -48,10 +48,11 @@
     transition: transform 0.2s;
 
     .image {
+      aspect-ratio: 1.778;
       flex-shrink: 0;
-      height: 11.5rem;
       overflow: hidden;
       position: relative;
+      width: 100%;
     }
 
     .contents {

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -70,6 +70,16 @@ const EventsPage = ({ events, attendances }: EventsPageProps) => {
   const filteredEvents = events.filter(e =>
     filterEvent(e, attendances, { query, communityFilter, dateFilter, attendedFilter })
   );
+
+  filteredEvents.sort((a, b) => {
+    if (dateFilter === 'upcoming') {
+      // For upcoming events, sort from soonest to latest
+      return new Date(a.start).getTime() - new Date(b.start).getTime();
+    }
+    // For all other events, sort from most recent to least recent
+    return new Date(b.start).getTime() - new Date(a.start).getTime();
+  });
+
   const displayedEvents = filteredEvents.slice(page * ROWS_PER_PAGE, (page + 1) * ROWS_PER_PAGE);
 
   return (


### PR DESCRIPTION
# Description

What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context.

- Allow years to be displayed on EventCard (this is specifically for the big Events page)
- Add an implicit sort for events on the events page (for upcoming, smallest dates first, otherwise largest dates)
- Enforce an aspect ratio for EventModal (this helps graphics look better on prod specifically)

# Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [x] locally on mobile - use https://ngrok.io to get a copy on a mobile device
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have run and passed all new and existing Cypress tests. Add screenshots below.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented my code's `src/lib` functions and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

Cards include the year
<img width="1440" alt="Screenshot 2024-01-01 at 7 36 36 PM" src="https://github.com/acmucsd/membership-portal-ui-v2/assets/27360825/8df5d10b-d27e-45b2-a5cd-6a724b994577">

New modal tweaks
<img width="1440" alt="Screenshot 2024-01-01 at 7 36 47 PM" src="https://github.com/acmucsd/membership-portal-ui-v2/assets/27360825/c313fa24-1bfe-4951-bd37-53a03c1d5de0">
<img width="209" alt="Screenshot 2024-01-01 at 7 37 20 PM" src="https://github.com/acmucsd/membership-portal-ui-v2/assets/27360825/f1492a0f-7982-4188-9ed8-dbb7b0535dd7">
