### PR TITLE
Faris/cleanup optimizations

### DIFF
--- a/src/components/events/CalendarButtons/index.tsx
+++ b/src/components/events/CalendarButtons/index.tsx
@@ -88,6 +88,7 @@ const CalendarButtons = ({ event }: CalendarButtonProps) => {
           className={styles.calendarLink}
           href={appleCalInfo.href}
           download={appleCalInfo.download}
+          suppressHydrationWarning
         >
           <AppleCalendarLogo className={styles.appleCalLogo} alt="apple calendar" />
           <Typography variant="h6/bold">Add to Apple Calendar</Typography>

--- a/src/components/events/EventModal/index.tsx
+++ b/src/components/events/EventModal/index.tsx
@@ -20,7 +20,10 @@ const EventModal = ({ open, attended, event, onClose }: EventModalProps) => {
   const { cover, title, start, end, location, description, eventLink } = event;
 
   const displayCover = cover || '/assets/graphics/store/hero-photo.jpg';
-  const displayEventLink = eventLink || `https://acmucsd.com/events/${event.uuid}`;
+  const formattedEventLink = eventLink?.includes('https://') ? eventLink : `https://${eventLink}`;
+  const displayEventLink = eventLink
+    ? formattedEventLink
+    : `https://acmucsd.com/events/${event.uuid}`;
 
   const ref = useRef<HTMLDialogElement>(null);
 

--- a/src/components/leaderboard/TopThreeCard/index.tsx
+++ b/src/components/leaderboard/TopThreeCard/index.tsx
@@ -24,6 +24,7 @@ const TopThreeCard = ({ position, rank, name, url, points, image }: UserCardProp
           alt="User Profile Pic"
           width={80}
           height={80}
+          unoptimized={isSrcAGif(image)}
         />
         <span className={styles.cardText}>{trim(name, 25)}</span>
         <span className={styles.cardText}>{rank}</span>

--- a/src/components/leaderboard/TopThreeCard/index.tsx
+++ b/src/components/leaderboard/TopThreeCard/index.tsx
@@ -1,4 +1,4 @@
-import { trim } from '@/lib/utils';
+import { isSrcAGif, trim } from '@/lib/utils';
 import Image from 'next/image';
 import Link from 'next/link';
 import styles from './style.module.scss';

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -61,7 +61,7 @@ const ROWS_PER_PAGE = 25;
 const EventsPage = ({ events, attendances }: EventsPageProps) => {
   const [page, setPage] = useState(0);
   const [communityFilter, setCommunityFilter] = useState('all');
-  const [dateFilter, setDateFilter] = useState('upcoming');
+  const [dateFilter, setDateFilter] = useState('all-time');
   const [attendedFilter, setAttendedFilter] = useState('all');
   const [query, setQuery] = useState('');
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,6 @@ import type {
 import { CookieType } from '@/lib/types/enums';
 import styles from '@/styles/pages/Home.module.scss';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 interface HomePageProps {
@@ -70,17 +69,15 @@ const PortalHomePage = ({
     }
   };
 
-  const router = useRouter();
-
   useEffect(() => {
     if (checkInResponse) {
       // In dev mode, this runs twice because of reactStrictMode in nextConfig.
       // This will only be run once in prod or deployment.
       processCheckInResponse(checkInResponse);
       // Clear the query params without re-triggering getServerSideProps.
-      router.push(`${config.homeRoute}`, undefined, { shallow: true });
+      window.history.replaceState(null, '', config.homeRoute);
     }
-  }, [checkInResponse, router]);
+  }, [checkInResponse]);
 
   return (
     <div className={styles.page}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { EventCarousel } from '@/components/events';
 import Hero from '@/components/home/Hero';
-import { showToast } from '@/lib';
+import { config, showToast } from '@/lib';
 import { EventAPI, UserAPI } from '@/lib/api';
 import withAccessType from '@/lib/hoc/withAccessType';
 import { attendEvent } from '@/lib/managers/EventManager';
@@ -14,6 +14,7 @@ import type {
 import { CookieType } from '@/lib/types/enums';
 import styles from '@/styles/pages/Home.module.scss';
 import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 interface HomePageProps {
@@ -69,15 +70,17 @@ const PortalHomePage = ({
     }
   };
 
+  const router = useRouter();
+
   useEffect(() => {
     if (checkInResponse) {
       // In dev mode, this runs twice because of reactStrictMode in nextConfig.
       // This will only be run once in prod or deployment.
       processCheckInResponse(checkInResponse);
       // Clear the query params without re-triggering getServerSideProps.
-      window.history.replaceState(null, '', '/');
+      router.push(`${config.homeRoute}`, undefined, { shallow: true });
     }
-  }, [checkInResponse]);
+  }, [checkInResponse, router]);
 
   return (
     <div className={styles.page}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -96,7 +96,7 @@ const PortalHomePage = ({
         <EventCarousel
           title="Upcoming Events"
           description="Mark your calendars! These events are just around the corner!"
-          events={upcomingEvents.slice(0, 10)} // Slicing past events so the carousel doesn't balloon.
+          events={upcomingEvents} // Slicing past events so the carousel doesn't balloon.
           attendances={attendance}
         />
       )}
@@ -105,7 +105,7 @@ const PortalHomePage = ({
         <EventCarousel
           title="Past Events"
           description="Take a look at some of ACM's past events!"
-          events={pastEvents.slice(-10).reverse()} // Slicing past events so the carousel doesn't balloon.
+          events={pastEvents} // Slicing past events so the carousel doesn't balloon.
           attendances={attendance}
         />
       )}
@@ -156,8 +156,8 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res, query }) =
   return {
     props: {
       user,
-      pastEvents,
-      upcomingEvents,
+      pastEvents: pastEvents.slice(-10).reverse(),
+      upcomingEvents: upcomingEvents.slice(0, 10),
       liveEvents,
       attendances,
       checkInResponse: checkInResponse,

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -111,7 +111,7 @@ const LeaderboardPage = ({ sort, leaderboard, user: { uuid } }: LeaderboardProps
           ]}
           value={sort}
           onChange={sort => {
-            router.push(`${config.leaderboardRoute}?sort=${sort}`, undefined, { shallow: true });
+            router.push(`${config.leaderboardRoute}?sort=${sort}`);
             setPage(0);
             setScrollIntoView(0);
           }}

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -111,7 +111,7 @@ const LeaderboardPage = ({ sort, leaderboard, user: { uuid } }: LeaderboardProps
           ]}
           value={sort}
           onChange={sort => {
-            router.push(`${config.leaderboardRoute}?sort=${sort}`);
+            router.push(`${config.leaderboardRoute}?sort=${sort}`, undefined, { shallow: true });
             setPage(0);
             setScrollIntoView(0);
           }}


### PR DESCRIPTION
some cleanup and optimizations for repo

- serversideprops should return as little data as possible, moved event slicing to serverside since the slice range is already hardcoded in
- shallow navigate page routes with native nextjs router to avoid recalculating serversideprops
- default event page to all time so the page isn't empty on initial load ever
- format event links without https:// correctly instead of assuming relative links
- fix hydration error trying to run the browser blob api serverside pre-rendering
- load gifs correctly in top 3 user cards