### PR TITLE
Internal Server Error Page

### DIFF
--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,0 +1,34 @@
+import { SignInButton } from '@/components/auth';
+import { VerticalForm } from '@/components/common';
+import Cat404 from '@/public/assets/graphics/cat404.png';
+import styles from '@/styles/pages/404.module.scss';
+import Image from 'next/image';
+
+const InternalServerError = () => {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 8.25rem)' }}>
+      <VerticalForm style={{ alignItems: 'center', flex: 'auto', height: 'unset' }}>
+        <h1 className={styles.header}>Something has gone terribly wrong</h1>
+        <Image src={Cat404} width={256} height={256} alt="Sad Cat" />
+        <span
+          style={{
+            textAlign: 'center',
+          }}
+        >
+          Logging out will usually fix your issue.
+        </span>
+        <SignInButton type="link" display="button1" href="/logout" text="Logout" />
+        <span
+          style={{
+            textAlign: 'center',
+          }}
+        >
+          If that doesn&apos;t work, file a bug to us on our project issue&apos;s page
+          <a href="https://github.com/acmucsd/membership-portal-ui-v2/issues"> here</a>
+        </span>
+      </VerticalForm>
+    </div>
+  );
+};
+
+export default InternalServerError;

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -23,8 +23,18 @@ const InternalServerError = () => {
             textAlign: 'center',
           }}
         >
-          If that doesn&apos;t work, file a bug to us on our project issue&apos;s page
-          <a href="https://github.com/acmucsd/membership-portal-ui-v2/issues"> here</a>
+          If that doesn&apos;t work, file a bug to us on our project issue&apos;s page&nbsp;
+          <a
+            href="https://github.com/acmucsd/membership-portal-ui-v2/issues/new"
+            style={{
+              color: 'var(--theme-primary-4)',
+              textDecoration: 'underline',
+              fontWeight: '700',
+            }}
+          >
+            here
+          </a>
+          .
         </span>
       </VerticalForm>
     </div>


### PR DESCRIPTION
custom 500 page makes it easier to recover to a stable client state by logging out (clearing all cookies)

can design something nicer later on

this page will be hit when serversideprops hits an exception such as 
- corrupted cookies
- existing but invalid auth token
- api goes down
- invalid api response

the first 2 cases are easily recoverable by logging out and the last 2 make the portal unusable anyways so they can't be solved by the user

# Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->
