### PR TITLE
Fix theme meta toggle, fix navbar padding

### DIFF
--- a/src/components/common/ThemeToggle/index.tsx
+++ b/src/components/common/ThemeToggle/index.tsx
@@ -6,7 +6,7 @@ import { useEffect, useId, useState } from 'react';
 import styles from './style.module.scss';
 
 const ThemeToggle = () => {
-  const { theme = 'system', setTheme } = useTheme();
+  const { theme = 'system', resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   const lightId = `light${useId()}`;
@@ -23,6 +23,15 @@ const ThemeToggle = () => {
 
   const switchPos = themeToSwitch[theme];
   const currAltText = `Icon representing ${theme} theme is on.`;
+
+  useEffect(() => {
+    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+    if (metaThemeColor && resolvedTheme === 'dark') {
+      metaThemeColor.setAttribute('content', '#37393e');
+    } else if (metaThemeColor) {
+      metaThemeColor.setAttribute('content', '#fff');
+    }
+  }, [resolvedTheme]);
 
   useEffect(() => {
     setMounted(true);

--- a/src/components/common/ThemeToggle/index.tsx
+++ b/src/components/common/ThemeToggle/index.tsx
@@ -25,6 +25,8 @@ const ThemeToggle = () => {
   const currAltText = `Icon representing ${theme} theme is on.`;
 
   useEffect(() => {
+    // Adjusting the <meta name="theme-color"> tag.
+    // This affects the color of the safe zone on iPhone 15.
     const metaThemeColor = document.querySelector('meta[name="theme-color"]');
     if (metaThemeColor && resolvedTheme === 'dark') {
       metaThemeColor.setAttribute('content', '#37393e');

--- a/src/components/layout/Navbar/index.tsx
+++ b/src/components/layout/Navbar/index.tsx
@@ -57,7 +57,7 @@ const Navbar = ({ accessType }: NavbarProps) => {
           </Link>
           <ThemeToggle />
         </div>
-        <hr className={styles.wainbow} />
+        <hr className={`${styles.wainbow} ${styles.loggedOut}`} />
       </header>
     );
   }

--- a/src/components/layout/Navbar/style.module.scss
+++ b/src/components/layout/Navbar/style.module.scss
@@ -165,6 +165,10 @@
     height: 0.25rem;
     margin: 0 -1rem;
     width: 100vw;
+
+    &.loggedOut {
+      margin: 0;
+    }
   }
 }
 

--- a/src/components/layout/Navbar/style.module.scss.d.ts
+++ b/src/components/layout/Navbar/style.module.scss.d.ts
@@ -7,6 +7,7 @@ export type Styles = {
   icon: string;
   iconLink: string;
   iconLinks: string;
+  loggedOut: string;
   mobileNav: string;
   mobileNavItem: string;
   navLeft: string;


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

- Fixing a bug where the safe area on an iPhone 15 wouldn't change colors with the theme
- Also fixing a bug with navbar padding while logged out

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.
