### PR TITLE
Make admin event mobile responsive, remove unused CSS in CheckInModal

### DIFF
--- a/src/components/admin/event/EventDetailsForm/index.tsx
+++ b/src/components/admin/event/EventDetailsForm/index.tsx
@@ -288,9 +288,6 @@ const EventDetailsForm = (props: IProps) => {
 
         <label htmlFor="cover">Cover Image</label>
         <DetailsFormItem>
-          {eventCover ? (
-            <Image src={eventCover} alt="Selected cover image" width={480} height={270} />
-          ) : null}
           <input
             type="file"
             id="cover"
@@ -303,6 +300,16 @@ const EventDetailsForm = (props: IProps) => {
               }
             }}
           />
+          {eventCover ? (
+            <div className={style.eventCover}>
+              <Image
+                src={eventCover}
+                alt="Selected cover image"
+                style={{ objectFit: 'cover' }}
+                fill
+              />
+            </div>
+          ) : null}
         </DetailsFormItem>
         <Cropper
           file={selectedCover}

--- a/src/components/admin/event/EventDetailsForm/style.module.scss
+++ b/src/components/admin/event/EventDetailsForm/style.module.scss
@@ -17,10 +17,20 @@
     display: grid;
     grid-template-columns: 1fr 3fr;
     row-gap: 1rem;
+
+    .eventCover {
+      aspect-ratio: 1920 / 1080;
+      position: relative;
+      width: 100%;
+    }
+    @media screen and (width <= vars.$breakpoint-md) {
+      grid-template-columns: unset;
+    }
   }
 
   .submitButtons {
     display: flex;
+    flex-wrap: wrap;
     gap: 1rem;
   }
 }

--- a/src/components/admin/event/EventDetailsForm/style.module.scss.d.ts
+++ b/src/components/admin/event/EventDetailsForm/style.module.scss.d.ts
@@ -1,6 +1,7 @@
 export type Styles = {
   back: string;
   container: string;
+  eventCover: string;
   form: string;
   submitButtons: string;
 };

--- a/src/components/admin/event/NotionAutofill/style.module.scss
+++ b/src/components/admin/event/NotionAutofill/style.module.scss
@@ -10,6 +10,7 @@
 
   .row {
     display: flex;
+    flex-wrap: wrap;
     gap: 1rem;
     width: 100%;
 

--- a/src/components/events/CheckInModal/style.module.scss
+++ b/src/components/events/CheckInModal/style.module.scss
@@ -44,24 +44,6 @@
         }
       }
     }
-
-    .close {
-      align-items: center;
-      background: none;
-      display: flex;
-      height: 3.75rem;
-      margin-left: 1rem;
-      padding: 0;
-    }
-  }
-
-  .image {
-    aspect-ratio: 1920 / 1080;
-    border-radius: 10px;
-    flex-shrink: 0;
-    overflow: hidden;
-    position: relative;
-    width: 100%;
   }
 
   .done {

--- a/src/components/events/CheckInModal/style.module.scss.d.ts
+++ b/src/components/events/CheckInModal/style.module.scss.d.ts
@@ -1,11 +1,9 @@
 export type Styles = {
-  close: string;
   container: string;
   done: string;
   graphic: string;
   header: string;
   headerText: string;
-  image: string;
   subheader: string;
   subheaderText: string;
 };


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

Closes **#146**.

## Changes

- Makes Admin Event Form mobile responsive
  - labels pop up over form item, flex wraps on buttons, image resizes with width
- Also removing unused CSS from CheckInModal that was left from previous iterations

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots
Desktop (original)
https://github.com/acmucsd/membership-portal-ui-v2/assets/27360825/3e298c97-9887-4dd4-ae2e-2a64c375da2e

Mobile (new)
https://github.com/acmucsd/membership-portal-ui-v2/assets/27360825/29765e52-3dca-4e2f-8014-868bc68ec9a8



