### PR TITLE
Sean/collection images

### DIFF
--- a/src/components/admin/store/DetailsForm/CollectionDetailsForm.tsx
+++ b/src/components/admin/store/DetailsForm/CollectionDetailsForm.tsx
@@ -1,33 +1,44 @@
 import DetailsFormItem from '@/components/admin/DetailsFormItem';
-import { Button } from '@/components/common';
+import { Photo } from '@/components/admin/store/DetailsForm/types';
+import { Button, Cropper, DRAG_HANDLE, Draggable } from '@/components/common';
 import { config, showToast } from '@/lib';
 import { AdminStoreManager } from '@/lib/managers';
 import { MerchCollection } from '@/lib/types/apiRequests';
 import { PublicMerchCollection } from '@/lib/types/apiResponses';
 import { reportError } from '@/lib/utils';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { BsArrowRight } from 'react-icons/bs';
+import { BsArrowRight, BsPlus } from 'react-icons/bs';
 import style from './style.module.scss';
 
-type FormValues = MerchCollection;
+type FormValues = Omit<MerchCollection, 'collectionPhotos'>;
 
 interface IProps {
   mode: 'create' | 'edit';
-  defaultData?: Partial<PublicMerchCollection>;
+  defaultData?: PublicMerchCollection;
   token: string;
 }
 
-const CollectionDetailsForm = ({ mode, defaultData = {}, token }: IProps) => {
+const CollectionDetailsForm = ({ mode, defaultData, token }: IProps) => {
   const router = useRouter();
-  const initialValues: FormValues = {
-    title: defaultData.title ?? '',
-    themeColorHex: defaultData.themeColorHex ?? style.defaultThemeColorHex,
-    description: defaultData.description ?? '',
-    archived: defaultData.archived ?? false,
-  };
+  const [lastSaved, setLastSaved] = useState<PublicMerchCollection | null>(defaultData ?? null);
+  const initialValues: FormValues = useMemo(
+    () => ({
+      title: lastSaved?.title ?? '',
+      themeColorHex: lastSaved?.themeColorHex ?? style.defaultThemeColorHex,
+      description: lastSaved?.description ?? '',
+      archived: lastSaved?.archived ?? false,
+    }),
+    [lastSaved]
+  );
+
+  const [photos, setPhotos] = useState<Photo[]>(
+    () => lastSaved?.collectionPhotos?.sort((a, b) => a.position - b.position) ?? []
+  );
+  const [photo, setPhoto] = useState<File | null>(null);
 
   const {
     register,
@@ -44,7 +55,14 @@ const CollectionDetailsForm = ({ mode, defaultData = {}, token }: IProps) => {
     setLoading(true);
 
     try {
-      const uuid = await AdminStoreManager.createNewCollection(token, formData);
+      const uuid = await AdminStoreManager.createNewCollection(
+        token,
+        {
+          ...formData,
+          collectionPhotos: [],
+        },
+        photos.flatMap(photo => (photo.uuid !== undefined ? [] : [photo.blob]))
+      );
       showToast('Collection created successfully!', '', [
         {
           text: 'Continue editing',
@@ -59,11 +77,27 @@ const CollectionDetailsForm = ({ mode, defaultData = {}, token }: IProps) => {
   };
 
   const editCollection: SubmitHandler<FormValues> = async formData => {
+    if (!lastSaved) {
+      return;
+    }
     setLoading(true);
 
     try {
-      const uuid = defaultData.uuid ?? '';
-      await AdminStoreManager.editCollection(token, uuid, formData);
+      const { uuid } = lastSaved;
+      const collection = await AdminStoreManager.editCollection(
+        token,
+        uuid,
+        lastSaved,
+        formData,
+        photos.map(photo => (photo.uuid !== undefined ? photo.uuid : photo.blob))
+      );
+      setLastSaved(collection);
+      photos.forEach(photo => {
+        if (!photo.uuid) {
+          URL.revokeObjectURL(photo.uploadedPhoto);
+        }
+      });
+      setPhotos(collection.collectionPhotos.sort((a, b) => a.position - b.position));
       showToast('Collection details saved!', '', [
         {
           text: 'View public collection page',
@@ -78,10 +112,13 @@ const CollectionDetailsForm = ({ mode, defaultData = {}, token }: IProps) => {
   };
 
   const deleteCollection = async () => {
+    if (!lastSaved) {
+      return;
+    }
     setLoading(true);
 
     try {
-      await AdminStoreManager.deleteCollection(token, defaultData.uuid ?? '');
+      await AdminStoreManager.deleteCollection(token, lastSaved.uuid ?? '');
       showToast('Collection deleted successfully');
       router.replace(config.store.homeRoute);
     } catch (error) {
@@ -91,88 +128,146 @@ const CollectionDetailsForm = ({ mode, defaultData = {}, token }: IProps) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(mode === 'edit' ? editCollection : createCollection)}>
-      <div className={style.header}>
-        <h1>{mode === 'edit' ? 'Modify' : 'Create'} Collection</h1>
+    <>
+      <form onSubmit={handleSubmit(mode === 'edit' ? editCollection : createCollection)}>
+        <div className={style.header}>
+          <h1>{mode === 'edit' ? 'Modify' : 'Create'} Collection</h1>
 
-        {defaultData.uuid ? (
-          <Link
-            className={style.viewPage}
-            href={`${config.store.collectionRoute}${defaultData.uuid}`}
-          >
-            View collection page
-            <BsArrowRight aria-hidden />
-          </Link>
-        ) : null}
-      </div>
+          {lastSaved ? (
+            <Link
+              className={style.viewPage}
+              href={`${config.store.collectionRoute}${lastSaved.uuid}`}
+            >
+              View collection page
+              <BsArrowRight aria-hidden />
+            </Link>
+          ) : null}
+        </div>
 
-      <div className={style.form}>
-        <label htmlFor="title">Title</label>
-        <DetailsFormItem error={errors.title?.message}>
-          <input
-            type="text"
-            id="title"
-            placeholder="The Raccoon Collection"
-            {...register('title', {
-              required: 'Required',
-            })}
-          />
+        <div className={style.form}>
+          <label htmlFor="title">Title</label>
+          <DetailsFormItem error={errors.title?.message}>
+            <input
+              type="text"
+              id="title"
+              placeholder="The Raccoon Collection"
+              {...register('title', {
+                required: 'Required',
+              })}
+            />
+          </DetailsFormItem>
+
+          <label htmlFor="description">Description</label>
+          <DetailsFormItem error={errors.description?.message}>
+            <textarea
+              id="description"
+              {...register('description', {
+                required: 'Required',
+              })}
+            />
+          </DetailsFormItem>
+
+          <label htmlFor="themeColorHex">Theme color</label>
+          <DetailsFormItem error={errors.themeColorHex?.message}>
+            <input
+              type="color"
+              id="themeColorHex"
+              {...register('themeColorHex', {
+                required: 'Required',
+              })}
+            />
+          </DetailsFormItem>
+        </div>
+
+        <ul className={style.photos}>
+          <Draggable items={photos} onReorder={setPhotos}>
+            {(props, photo, i) => (
+              <li key={photo.uuid ?? i} {...props}>
+                <Image
+                  className={DRAG_HANDLE}
+                  src={photo.uploadedPhoto}
+                  alt="Uploaded photo of store item"
+                  draggable={false}
+                  fill
+                />
+                <Button
+                  onClick={() => {
+                    setPhotos(photos.filter((_, index) => index !== i));
+                    if (photo.uuid === undefined) {
+                      URL.revokeObjectURL(photo.uploadedPhoto);
+                    }
+                  }}
+                  destructive
+                >
+                  Remove
+                </Button>
+              </li>
+            )}
+          </Draggable>
+          <li>
+            <label className={style.addImage}>
+              <BsPlus aria-hidden />
+              Add image
+              <input
+                type="file"
+                id="cover"
+                accept="image/*"
+                onChange={e => {
+                  const file = e.currentTarget.files?.[0];
+                  e.currentTarget.value = '';
+                  if (file) {
+                    setPhoto(file);
+                  }
+                }}
+              />
+            </label>
+          </li>
+        </ul>
+
+        <DetailsFormItem error={errors.archived?.message}>
+          <label>
+            <input type="checkbox" {...register('archived')} />
+            &nbsp;Archived?
+          </label>
         </DetailsFormItem>
 
-        <label htmlFor="description">Description</label>
-        <DetailsFormItem error={errors.description?.message}>
-          <textarea
-            id="description"
-            {...register('description', {
-              required: 'Required',
-            })}
-          />
-        </DetailsFormItem>
-
-        <label htmlFor="themeColorHex">Theme color</label>
-        <DetailsFormItem error={errors.themeColorHex?.message}>
-          <input
-            type="color"
-            id="themeColorHex"
-            {...register('themeColorHex', {
-              required: 'Required',
-            })}
-          />
-        </DetailsFormItem>
-      </div>
-
-      <DetailsFormItem error={errors.archived?.message}>
-        <label>
-          <input type="checkbox" {...register('archived')} />
-          &nbsp;Archived?
-        </label>
-      </DetailsFormItem>
-
-      <div className={style.submitButtons}>
-        {mode === 'edit' ? (
-          <>
-            <Button submit disabled={loading}>
-              Save changes
-            </Button>
-            <Button onClick={resetForm} disabled={loading} destructive>
-              Discard changes
-            </Button>
-            <Button onClick={deleteCollection} disabled={loading} destructive>
-              Delete collection
-            </Button>
-          </>
-        ) : (
-          <>
-            <Button submit disabled={loading}>
-              Create collection
-            </Button>
-            <Button onClick={resetForm} disabled={loading} destructive>
-              Clear form
-            </Button>
-          </>
-        )}
-      </div>
-    </form>
+        <div className={style.submitButtons}>
+          {mode === 'edit' ? (
+            <>
+              <Button submit disabled={loading}>
+                Save changes
+              </Button>
+              <Button onClick={resetForm} disabled={loading} destructive>
+                Discard changes
+              </Button>
+              <Button onClick={deleteCollection} disabled={loading} destructive>
+                Delete collection
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button submit disabled={loading}>
+                Create collection
+              </Button>
+              <Button onClick={resetForm} disabled={loading} destructive>
+                Clear form
+              </Button>
+            </>
+          )}
+        </div>
+      </form>
+      <Cropper
+        file={photo}
+        aspectRatio={1}
+        maxSize={config.file.MAX_COLLECTION_PHOTO_SIZE_KB * 1024}
+        maxFileHeight={1080}
+        onCrop={async blob => {
+          setPhotos(photos => [...photos, { blob, uploadedPhoto: URL.createObjectURL(blob) }]);
+          setPhoto(null);
+        }}
+        onClose={() => setPhoto(null)}
+      />
+    </>
   );
 };
 

--- a/src/components/admin/store/DetailsForm/ItemDetailsForm.tsx
+++ b/src/components/admin/store/DetailsForm/ItemDetailsForm.tsx
@@ -1,4 +1,5 @@
 import DetailsFormItem from '@/components/admin/DetailsFormItem';
+import { Photo } from '@/components/admin/store/DetailsForm/types';
 import ItemOptionsEditor, { type Option } from '@/components/admin/store/ItemOptionsEditor';
 import { Button, Cropper, DRAG_HANDLE, Draggable } from '@/components/common';
 import { config, showToast } from '@/lib';
@@ -20,9 +21,7 @@ import { BsArrowRight, BsPlus } from 'react-icons/bs';
 import style from './style.module.scss';
 
 type FormValues = Omit<MerchItem, 'uuid' | 'hasVariantsEnabled' | 'merchPhotos' | 'options'>;
-type Photo =
-  | { uuid: UUID; uploadedPhoto: string }
-  | { uuid?: undefined; blob: Blob; uploadedPhoto: string };
+
 const stringifyOption = ({
   uuid,
   price,
@@ -77,8 +76,8 @@ const ItemDetailsForm = ({ mode, defaultData, token, collections }: IProps) => {
   ];
   const [options, setOptions] = useState<Option[]>(defaultOptions);
 
-  const defaultMerchPhotos = lastSaved?.merchPhotos?.sort((a, b) => a.position - b.position) ?? [];
-  const [merchPhotos, setMerchPhotos] = useState<Photo[]>(defaultMerchPhotos);
+  const defaultPhotos = lastSaved?.merchPhotos?.sort((a, b) => a.position - b.position) ?? [];
+  const [photos, setPhotos] = useState<Photo[]>(defaultPhotos);
   const [photo, setPhoto] = useState<File | null>(null);
 
   const {
@@ -94,7 +93,7 @@ const ItemDetailsForm = ({ mode, defaultData, token, collections }: IProps) => {
     reset(initialValues);
     setOptionType(defaultOptionType);
     setOptions(defaultOptions);
-    setMerchPhotos(defaultMerchPhotos);
+    setPhotos(defaultPhotos);
   };
 
   const createItem: SubmitHandler<FormValues> = async formData => {
@@ -115,7 +114,7 @@ const ItemDetailsForm = ({ mode, defaultData, token, collections }: IProps) => {
               options.length > 1 ? { type: optionType, value: option.value, position } : undefined,
           })),
         },
-        merchPhotos.flatMap(photo => (photo.uuid !== undefined ? [] : [photo.blob]))
+        photos.flatMap(photo => (photo.uuid !== undefined ? [] : [photo.blob]))
       );
       showToast('Item created successfully!', '', [
         {
@@ -151,7 +150,7 @@ const ItemDetailsForm = ({ mode, defaultData, token, collections }: IProps) => {
           uuid: option.uuid,
           variant: option.value,
         })),
-        merchPhotos.map(photo => (photo.uuid !== undefined ? photo.uuid : photo.blob))
+        photos.map(photo => (photo.uuid !== undefined ? photo.uuid : photo.blob))
       );
       setLastSaved(item);
       setOptions(
@@ -159,12 +158,12 @@ const ItemDetailsForm = ({ mode, defaultData, token, collections }: IProps) => {
           .sort((a, b) => (a.metadata?.position ?? 0) - (b.metadata?.position ?? 0))
           .map(stringifyOption)
       );
-      merchPhotos.forEach(photo => {
+      photos.forEach(photo => {
         if (!photo.uuid) {
           URL.revokeObjectURL(photo.uploadedPhoto);
         }
       });
-      setMerchPhotos(item.merchPhotos.sort((a, b) => a.position - b.position));
+      setPhotos(item.merchPhotos.sort((a, b) => a.position - b.position));
       showToast('Item details saved!', '', [
         {
           text: 'View public item page',
@@ -259,7 +258,7 @@ const ItemDetailsForm = ({ mode, defaultData, token, collections }: IProps) => {
         </div>
 
         <ul className={style.photos}>
-          <Draggable items={merchPhotos} onReorder={setMerchPhotos}>
+          <Draggable items={photos} onReorder={setPhotos}>
             {(props, photo, i) => (
               <li key={photo.uuid ?? i} {...props}>
                 <Image
@@ -271,7 +270,7 @@ const ItemDetailsForm = ({ mode, defaultData, token, collections }: IProps) => {
                 />
                 <Button
                   onClick={() => {
-                    setMerchPhotos(merchPhotos.filter((_, index) => index !== i));
+                    setPhotos(photos.filter((_, index) => index !== i));
                     if (photo.uuid === undefined) {
                       URL.revokeObjectURL(photo.uploadedPhoto);
                     }
@@ -348,7 +347,7 @@ const ItemDetailsForm = ({ mode, defaultData, token, collections }: IProps) => {
         maxSize={config.file.MAX_MERCH_PHOTO_SIZE_KB * 1024}
         maxFileHeight={1080}
         onCrop={async blob => {
-          setMerchPhotos(photos => [...photos, { blob, uploadedPhoto: URL.createObjectURL(blob) }]);
+          setPhotos(photos => [...photos, { blob, uploadedPhoto: URL.createObjectURL(blob) }]);
           setPhoto(null);
         }}
         onClose={() => setPhoto(null)}

--- a/src/components/admin/store/DetailsForm/types.ts
+++ b/src/components/admin/store/DetailsForm/types.ts
@@ -1,0 +1,5 @@
+import { UUID } from '@/lib/types';
+
+export type Photo =
+  | { uuid: UUID; uploadedPhoto: string }
+  | { uuid?: undefined; blob: Blob; uploadedPhoto: string };

--- a/src/lib/api/StoreAPI.ts
+++ b/src/lib/api/StoreAPI.ts
@@ -7,11 +7,13 @@ import {
   EditMerchCollectionRequest,
   EditMerchItemRequest,
   MerchCollection,
+  MerchCollectionEdit,
   MerchItem,
   MerchItemEdit,
   MerchItemOption,
 } from '@/lib/types/apiRequests';
 import type {
+  CreateCollectionPhotoResponse,
   CreateMerchCollectionResponse,
   CreateMerchItemOptionResponse,
   CreateMerchItemResponse,
@@ -27,6 +29,7 @@ import type {
   GetOneMerchOrderResponse,
   GetOrderPickupEventsResponse,
   PublicMerchCollection,
+  PublicMerchCollectionPhoto,
   PublicMerchItem,
   PublicMerchItemOption,
   PublicMerchItemPhoto,
@@ -238,7 +241,7 @@ export const createCollection = async (
 export const editCollection = async (
   token: string,
   uuid: UUID,
-  collection: MerchCollection
+  collection: MerchCollectionEdit
 ): Promise<PublicMerchCollection> => {
   const requestUrl = `${config.api.baseUrl}${config.api.endpoints.store.collection}/${uuid}`;
 
@@ -317,6 +320,50 @@ export const getCollection = async (
   });
 
   return response.data.collection;
+};
+
+/**
+ * Upload a photo for a store collection
+ * @param token Authorization bearer token
+ * @param uuid Store collection UUID
+ * @param image Photo
+ * @param position The position of the image
+ * @returns The store collection photo object
+ */
+export const createCollectionPhoto = async (
+  token: string,
+  uuid: UUID,
+  image: Blob,
+  position = 0
+): Promise<PublicMerchCollectionPhoto> => {
+  const requestUrl = `${config.api.baseUrl}${config.api.endpoints.store.collectionPicture}/${uuid}`;
+
+  const requestBody = new FormData();
+  requestBody.append('position', `${position}`);
+  requestBody.append('image', image);
+
+  const response = await axios.post<CreateCollectionPhotoResponse>(requestUrl, requestBody, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return response.data.collectionPhoto;
+};
+
+/**
+ * Delete a merch collection photo
+ * @param token Authorization bearer token
+ * @param uuid Merch collection *photo* UUID
+ */
+export const deleteCollectionPhoto = async (token: string, uuid: UUID): Promise<void> => {
+  const requestUrl = `${config.api.baseUrl}${config.api.endpoints.store.collectionPicture}/${uuid}`;
+
+  await axios.delete(requestUrl, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
 };
 
 export const getFutureOrderPickupEvents = async (

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -40,6 +40,7 @@ const config = {
       leaderboard: '/leaderboard',
       store: {
         collection: '/merch/collection',
+        collectionPicture: '/merch/collection/picture',
         item: '/merch/item',
         itemPicture: '/merch/item/picture',
         option: '/merch/option',
@@ -118,6 +119,7 @@ const config = {
     MAX_PROFILE_PICTURE_SIZE_KB: 256,
     MAX_BANNER_SIZE_KB: isDevelopment ? 256 : 2048,
     MAX_MERCH_PHOTO_SIZE_KB: 1024,
+    MAX_COLLECTION_PHOTO_SIZE_KB: 1024,
     MAX_RESUME_SIZE_KB: isDevelopment ? 256 : 2048,
   },
 };

--- a/src/lib/types/apiRequests.ts
+++ b/src/lib/types/apiRequests.ts
@@ -189,6 +189,11 @@ export interface AttendEventRequest {
   asStaff?: boolean;
 }
 
+export interface AttendViaExpressCheckinRequest {
+  attendanceCode: string;
+  email: string;
+}
+
 export interface SubmitEventFeedbackRequest {
   feedback: string[];
 }
@@ -208,6 +213,10 @@ export interface CreateMerchCollectionRequest {
 
 export interface EditMerchCollectionRequest {
   collection: MerchCollectionEdit;
+}
+
+export interface CreateCollectionPhotoRequest {
+  position: string;
 }
 
 export interface CreateMerchItemRequest {
@@ -243,7 +252,7 @@ export interface RescheduleOrderPickupRequest {
   pickupEvent: UUID;
 }
 
-export interface MerchCollection {
+export interface CommonCollectionProperties {
   title: string;
   /** 6 digits, starts with `#` */
   themeColorHex?: string;
@@ -251,8 +260,23 @@ export interface MerchCollection {
   archived?: boolean;
 }
 
-export interface MerchCollectionEdit extends Partial<MerchCollection> {
+export interface MerchCollectionPhoto {
+  uploadedPhoto: string;
+  position: number;
+}
+
+export interface MerchCollectionPhotoEdit {
+  uuid: string;
+  position?: number;
+}
+
+export interface MerchCollection extends Partial<CommonCollectionProperties> {
+  collectionPhotos: MerchCollectionPhoto[];
+}
+
+export interface MerchCollectionEdit extends Partial<CommonCollectionProperties> {
   discountPercentage?: number;
+  collectionPhotos?: MerchCollectionPhotoEdit[];
 }
 
 export interface CommonMerchItemProperties {
@@ -326,6 +350,7 @@ export interface OrderPickupEvent {
   end: Date;
   description: string;
   orderLimit: number;
+  linkedEventUuid?: UUID;
 }
 
 export interface OrderPickupEventEdit extends Partial<OrderPickupEvent> {}

--- a/src/lib/types/apiResponses.ts
+++ b/src/lib/types/apiResponses.ts
@@ -84,6 +84,12 @@ export interface AttendEventResponse extends ApiResponse {
   event: PublicEvent;
 }
 
+export interface PublicExpressCheckin {
+  email: string;
+  event: PublicEvent;
+  timestamp: Date;
+}
+
 // AUTH
 
 export interface RegistrationResponse extends ApiResponse {
@@ -173,6 +179,7 @@ export interface PublicMerchCollection {
   description: string;
   archived?: boolean;
   items: PublicMerchItem[];
+  collectionPhotos: PublicMerchCollectionPhoto[];
   createdAt: Date;
 }
 
@@ -210,6 +217,13 @@ export interface PublicMerchItemOption {
 }
 
 export interface PublicMerchItemPhoto {
+  uuid: UUID;
+  uploadedPhoto: string;
+  position: number;
+  uploadedAt: Date;
+}
+
+export interface PublicMerchCollectionPhoto {
   uuid: UUID;
   uploadedPhoto: string;
   position: number;
@@ -268,6 +282,12 @@ export interface EditMerchCollectionResponse extends ApiResponse {
 }
 
 export interface DeleteMerchCollectionResponse extends ApiResponse {}
+
+export interface CreateCollectionPhotoResponse extends ApiResponse {
+  collectionPhoto: PublicMerchCollectionPhoto;
+}
+
+export interface DeleteCollectionPhotoResponse extends ApiResponse {}
 
 export interface GetOneMerchItemResponse extends ApiResponse {
   item: PublicMerchItemWithPurchaseLimits;
@@ -338,7 +358,7 @@ export interface PublicProfile {
   major: string;
   bio: string | null;
   points: number;
-  userSocialMedia: PublicUserSocialMedia[];
+  userSocialMedia?: PublicUserSocialMedia[];
   isAttendancePublic: boolean;
 }
 
@@ -430,6 +450,7 @@ export interface PublicOrderPickupEvent {
   orders?: PublicOrderWithItems[];
   orderLimit?: number;
   status: OrderPickupEventStatus;
+  linkedEvent?: PublicEvent;
 }
 
 export interface GetOrderPickupEventsResponse extends ApiResponse {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,11 +2,14 @@ import defaultProfilePictures from '@/lib/constants/profilePictures';
 import ranks from '@/lib/constants/ranks';
 import showToast from '@/lib/showToast';
 import type { URL } from '@/lib/types';
-import type {
-  CustomErrorBody,
-  PublicMerchItem,
-  PublicProfile,
-  ValidatorError,
+import {
+  PublicMerchCollectionPhoto,
+  PublicMerchItemPhoto,
+  type CustomErrorBody,
+  type PublicMerchCollection,
+  type PublicMerchItem,
+  type PublicProfile,
+  type ValidatorError,
 } from '@/lib/types/apiResponses';
 import NoImage from '@/public/assets/graphics/cat404.png';
 import { AxiosError } from 'axios';
@@ -294,13 +297,47 @@ export const getDateRange = (sort: string | number) => {
  * Returns the default (first) photo for a merchandise item.
  * If there are no photos for this item, returns the default 404 image.
  */
-export const getDefaultMerchItemPhoto = (item: PublicMerchItem | undefined): string => {
+export const getDefaultMerchItemPhoto = (item?: PublicMerchItem): string => {
   if (item && item.merchPhotos.length > 0) {
     // Get the photo with the smallest position.
     const defaultPhoto = item.merchPhotos.reduce((prevImage, currImage) => {
       return prevImage.position < currImage.position ? prevImage : currImage;
     });
     return defaultPhoto.uploadedPhoto;
+  }
+  return NoImage.src;
+};
+
+/**
+ * Returns the default (first) photo for a merchandise collection.
+ * If there are no photos for this collection, returns the first photo of the first item.
+ * If there are no photos at all in the collection, returns the default 404 image.
+ */
+export const getDefaultMerchCollectionPhoto = (collection?: PublicMerchCollection): string => {
+  if (collection) {
+    // Get the photo with the smallest position.
+    const defaultCollectionPhoto =
+      collection.collectionPhotos.reduce<PublicMerchCollectionPhoto | null>(
+        (prevImage, currImage) => {
+          return prevImage && prevImage.position < currImage.position ? prevImage : currImage;
+        },
+        null
+      );
+    if (defaultCollectionPhoto) {
+      return defaultCollectionPhoto.uploadedPhoto;
+    }
+    const defaultItemPhoto = collection.items.reduce<PublicMerchItemPhoto | null>((image, item) => {
+      if (image) {
+        return image;
+      }
+      // Get the photo with the smallest position.
+      return item.merchPhotos.reduce<PublicMerchItemPhoto | null>((prevImage, currImage) => {
+        return prevImage && prevImage.position < currImage.position ? prevImage : currImage;
+      }, null);
+    }, null);
+    if (defaultItemPhoto) {
+      return defaultItemPhoto.uploadedPhoto;
+    }
   }
   return NoImage.src;
 };

--- a/src/pages/store/collection/[uuid].tsx
+++ b/src/pages/store/collection/[uuid].tsx
@@ -9,6 +9,8 @@ import { CookieType } from '@/lib/types/enums';
 import { getDefaultMerchItemPhoto } from '@/lib/utils';
 import styles from '@/styles/pages/StoreCollectionPage.module.scss';
 import { GetServerSideProps } from 'next';
+import Image from 'next/image';
+import { useMemo } from 'react';
 
 interface CollectionProps {
   uuid: string;
@@ -20,11 +22,16 @@ interface CollectionProps {
 const CollectionsPage = ({
   uuid,
   user: { credits, accessType },
-  collection: { title, description, items = [], archived },
+  collection: { title, description, items = [], archived, collectionPhotos },
   previewPublic,
 }: CollectionProps) => {
   const storeAdminVisible =
     PermissionService.canEditMerchItems.includes(accessType) && !previewPublic;
+
+  const photos = useMemo(
+    () => [...collectionPhotos].sort((a, b) => a.position - b.position),
+    [collectionPhotos]
+  );
 
   return (
     <div className={styles.container}>
@@ -39,6 +46,20 @@ const CollectionsPage = ({
           {description}
         </Typography>
       </div>
+      {photos.length > 0 ? (
+        <>
+          <div className={styles.photos}>
+            {photos.map(photo => (
+              <div className={styles.photo} key={photo.uuid}>
+                <Image src={photo.uploadedPhoto} alt={`Photo of ${title}`} fill />
+              </div>
+            ))}
+          </div>
+          <Typography variant="h2/bold" component="h2" className={styles.browseItems}>
+            Browse items
+          </Typography>
+        </>
+      ) : null}
       <div className={styles.collections}>
         {items
           .filter(item => storeAdminVisible || !item.hidden)

--- a/src/pages/store/index.tsx
+++ b/src/pages/store/index.tsx
@@ -14,7 +14,7 @@ import withAccessType from '@/lib/hoc/withAccessType';
 import { CookieService, PermissionService } from '@/lib/services';
 import { PrivateProfile, PublicMerchCollection } from '@/lib/types/apiResponses';
 import { CookieType } from '@/lib/types/enums';
-import { getDefaultMerchItemPhoto } from '@/lib/utils';
+import { getDefaultMerchCollectionPhoto } from '@/lib/utils';
 import styles from '@/styles/pages/StoreHomePage.module.scss';
 import { GetServerSideProps } from 'next';
 import Link from 'next/link';
@@ -99,7 +99,7 @@ const StoreHomePage = ({
           <div className={styles.collections}>
             {visibleCollections.map(collection => (
               <ItemCard
-                image={getDefaultMerchItemPhoto(collection.items[0])}
+                image={getDefaultMerchCollectionPhoto(collection)}
                 title={collection.title}
                 description={collection.description}
                 href={`${config.store.collectionRoute}${collection.uuid}`}

--- a/src/styles/pages/StoreCollectionPage.module.scss
+++ b/src/styles/pages/StoreCollectionPage.module.scss
@@ -18,6 +18,28 @@
     }
   }
 
+  .photos {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+
+    .photo {
+      aspect-ratio: 1;
+      position: relative;
+
+      img {
+        object-fit: cover;
+      }
+    }
+  }
+
+  @media (max-width: vars.$breakpoint-md) {
+    .photos,
+    .browseItems {
+      display: none;
+    }
+  }
+
   .collections {
     display: grid;
     gap: 1rem;

--- a/src/styles/pages/StoreCollectionPage.module.scss.d.ts
+++ b/src/styles/pages/StoreCollectionPage.module.scss.d.ts
@@ -1,7 +1,10 @@
 export type Styles = {
+  browseItems: string;
   collections: string;
   container: string;
   header: string;
+  photo: string;
+  photos: string;
 };
 
 export type ClassNames = keyof Styles;


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

Closes #134.

<!-- If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak. -->

show and edit collection images

**question**: what aspect ratio should collection photos be? currently they're 1:1, but that's not the case in the design

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

## Changes

- updated apiRequests/apiResponses
- added the draggable photos thingy from edit item page to collection page
- collection cards now use collection photos; they still default to item photos after that
- collection page has them photos too (desktop only)

# Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->

![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/dbe2cb12-d3a5-4b15-81bd-360e8b4725cd)

![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/e1aa6ed2-244c-4be1-9628-01f1a8113fd1)


![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/bd262b3b-1f0f-4293-8e0d-19b7ddde051a)
