### PR TITLE
Implement event cover src validation

### DIFF
--- a/src/components/events/EventCard/index.tsx
+++ b/src/components/events/EventCard/index.tsx
@@ -6,7 +6,7 @@ import {
   PublicOrderPickupEvent,
   PublicOrderPickupEventWithLinkedEvent,
 } from '@/lib/types/apiResponses';
-import { formatEventDate, isOrderPickupEvent } from '@/lib/utils';
+import { formatEventDate, getDefaultEventCover, isOrderPickupEvent } from '@/lib/utils';
 import Image from 'next/image';
 import { useState } from 'react';
 import styles from './style.module.scss';
@@ -38,7 +38,7 @@ const EventCard = ({
   const [expanded, setExpanded] = useState(false);
   const hasModal = !isOrderPickupEvent(event) || event.linkedEvent;
 
-  const displayCover = cover || '/assets/graphics/store/hero-photo.jpg';
+  const displayCover = getDefaultEventCover(cover);
 
   return (
     <>

--- a/src/components/events/EventDetail/index.tsx
+++ b/src/components/events/EventDetail/index.tsx
@@ -2,7 +2,7 @@ import { CommunityLogo, Typography } from '@/components/common';
 import CalendarButtons from '@/components/events/CalendarButtons';
 import PointsDisplay from '@/components/events/PointsDisplay';
 import { PublicEvent, PublicOrderPickupEvent } from '@/lib/types/apiResponses';
-import { fixUrl, formatEventDate, isOrderPickupEvent } from '@/lib/utils';
+import { fixUrl, formatEventDate, getDefaultEventCover, isOrderPickupEvent } from '@/lib/utils';
 import CloseIcon from '@/public/assets/icons/close-icon.svg';
 import LinkIcon from '@/public/assets/icons/link.svg';
 import Image from 'next/image';
@@ -25,7 +25,7 @@ const EventDetail = ({ event, attended, inModal = true }: EventDetailProps) => {
         }
       : event;
 
-  const displayCover = cover || '/assets/graphics/store/hero-photo.jpg';
+  const displayCover = getDefaultEventCover(cover);
   const uuidForLink = isOrderPickupEvent(event) ? event.linkedEvent?.uuid : event.uuid;
   const displayEventLink =
     fixUrl(eventLink ?? '') || (uuidForLink && `https://acmucsd.com/events/${uuidForLink}`) || '';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -418,6 +418,11 @@ export const getOrderItemQuantities = (items: PublicOrderItem[]): PublicOrderIte
   return Array.from(itemMap.values());
 };
 
+/**
+ * Validates src for event cover image, returning a default if invalid
+ * @param src src for cover image
+ * @returns a valid image src
+ */
 export const getDefaultEventCover = (src: any): string => {
   if (!src || typeof src !== 'string' || !/^(http|\/)/.test(src))
     return '/assets/graphics/store/hero-photo.jpg';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -424,7 +424,7 @@ export const getOrderItemQuantities = (items: PublicOrderItem[]): PublicOrderIte
  * @returns a valid image src
  */
 export const getDefaultEventCover = (src: unknown): string => {
-  if (!src || typeof src !== 'string' || !/^(http|\/)/.test(src))
+  if (!src || typeof src !== 'string' || !/^(http|\/).+(jpg|png|jpeg)$/i.test(src))
     return '/assets/graphics/store/hero-photo.jpg';
   return src;
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -417,3 +417,9 @@ export const getOrderItemQuantities = (items: PublicOrderItem[]): PublicOrderIte
 
   return Array.from(itemMap.values());
 };
+
+export const getDefaultEventCover = (src: any): string => {
+  if (!src || typeof src !== 'string' || !/^(http|\/)/.test(src))
+    return '/assets/graphics/store/hero-photo.jpg';
+  return src;
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -423,7 +423,7 @@ export const getOrderItemQuantities = (items: PublicOrderItem[]): PublicOrderIte
  * @param src src for cover image
  * @returns a valid image src
  */
-export const getDefaultEventCover = (src: any): string => {
+export const getDefaultEventCover = (src: unknown): string => {
   if (!src || typeof src !== 'string' || !/^(http|\/)/.test(src))
     return '/assets/graphics/store/hero-photo.jpg';
   return src;


### PR DESCRIPTION

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

## Changes

- Implements `getDefaultEventCover` in `utils.js` for validating event cover src
- EventCard and EventDetail now use above func for cover src

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->
