### PR TITLE
Fix next level text on user profile page

### DIFF
--- a/src/components/profile/UserProfilePage/index.tsx
+++ b/src/components/profile/UserProfilePage/index.tsx
@@ -31,6 +31,9 @@ export const UserProfilePage = ({
   const [progress, setProgress] = useState<Number>(0);
   useEffect(() => setProgress(handleUser.points % 100), [handleUser.points]);
   const levelText = `Level ${getLevel(handleUser.points)}: ${getUserRank(handleUser.points)}`;
+  const nextLevelText = `Level ${getLevel(handleUser.points + 100)}: ${getUserRank(
+    handleUser.points + 100
+  )}`;
 
   return (
     <div className={styles.profilePage}>
@@ -103,7 +106,7 @@ export const UserProfilePage = ({
           {isSignedInUser ? 'You need ' : `${handleUser.firstName} needs `}
           {100 - (handleUser.points % 100)} more points to level up to
           <Typography variant="h5/bold" component="span">
-            &nbsp;{levelText}
+            &nbsp;{nextLevelText}
           </Typography>
         </Typography>
       </div>


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

## Changes

- Fixing this bug where it said leveling up to the same level instead the next level

![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/27360825/a83f542b-5847-40c0-bf52-cddfa3553c62)

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->
