### PR TITLE
new event card design

### DIFF
--- a/src/components/common/CommunityLogo/index.tsx
+++ b/src/components/common/CommunityLogo/index.tsx
@@ -1,6 +1,5 @@
-import { communityLogos } from '@/lib/constants/communityLogos';
-import { Community } from '@/lib/types/enums';
-import { capitalize } from '@/lib/utils';
+import { communityLogos } from '@/lib/constants/communities';
+import { toCommunity } from '@/lib/utils';
 import Image from 'next/image';
 
 interface CommunityLogoProps {
@@ -9,14 +8,8 @@ interface CommunityLogoProps {
 }
 
 const CommunityLogo = ({ community, size }: CommunityLogoProps) => {
-  const formattedName = capitalize(community) as Community;
-
-  if (!Object.values(Community).includes(formattedName))
-    return <Image src={communityLogos.General} width={size} alt="ACM General Logo" />;
-
-  return (
-    <Image src={communityLogos[formattedName]} width={size} alt={`ACM ${formattedName} Logo`} />
-  );
+  const name = toCommunity(community);
+  return <Image src={communityLogos[name]} width={size} alt={`ACM ${name} Logo`} />;
 };
 
 export default CommunityLogo;

--- a/src/components/events/CheckInModal/style.module.scss.d.ts
+++ b/src/components/events/CheckInModal/style.module.scss.d.ts
@@ -1,6 +1,5 @@
 export type Styles = {
   ai: string;
-  close: string;
   container: string;
   cyber: string;
   design: string;
@@ -10,7 +9,6 @@ export type Styles = {
   hack: string;
   header: string;
   headerText: string;
-  image: string;
   innovate: string;
   subheader: string;
   subheaderText: string;

--- a/src/components/events/EventCard/index.tsx
+++ b/src/components/events/EventCard/index.tsx
@@ -78,25 +78,31 @@ const EventCard = ({
         </div>
         {!hideInfo && (
           <div className={styles.info}>
-            <Typography
-              variant="body/small"
-              style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
-              suppressHydrationWarning
-            >
-              {formatEventDate(start, end, showYear)}
-            </Typography>
-            <Typography
-              variant="body/medium"
-              style={{ fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis' }}
-            >
-              {title}
-            </Typography>
-            <Typography
-              variant="body/small"
-              style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
-            >
-              {location}
-            </Typography>
+            <div className={styles.infoText}>
+              <Typography
+                variant="body/small"
+                style={{
+                  fontWeight: 500,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+                suppressHydrationWarning
+              >
+                {formatEventDate(start, end, showYear)}
+              </Typography>
+              <Typography
+                variant="body/medium"
+                style={{ fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis' }}
+              >
+                {title}
+              </Typography>
+              <Typography
+                variant="body/small"
+                style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+              >
+                {location}
+              </Typography>
+            </div>
             <div className={styles.badges}>
               <div className={`${styles.badge} ${styles[`badge${community}`]}`}>
                 {communityNames[community]}

--- a/src/components/events/EventCard/index.tsx
+++ b/src/components/events/EventCard/index.tsx
@@ -104,9 +104,11 @@ const EventCard = ({
               </Typography>
             </div>
             <div className={styles.badges}>
-              <div className={`${styles.badge} ${styles[`badge${community}`]}`}>
-                {communityNames[community]}
-              </div>
+              {committee ? (
+                <div className={`${styles.badge} ${styles[`badge${community}`]}`}>
+                  {communityNames[community]}
+                </div>
+              ) : null}
               {!isOrderPickupEvent(event) ? (
                 <div className={`${styles.badge} ${styles.badgePoints}`}>
                   {event.pointValue} point{event.pointValue === 1 ? '' : 's'}

--- a/src/components/events/EventCard/index.tsx
+++ b/src/components/events/EventCard/index.tsx
@@ -1,12 +1,12 @@
-import { CommunityLogo, Typography } from '@/components/common';
+import { Typography } from '@/components/common';
 import EventModal from '@/components/events/EventModal';
-import PointsDisplay from '@/components/events/PointsDisplay';
+import { communityNames } from '@/lib/constants/communities';
 import {
   PublicEvent,
   PublicOrderPickupEvent,
   PublicOrderPickupEventWithLinkedEvent,
 } from '@/lib/types/apiResponses';
-import { formatEventDate, isOrderPickupEvent } from '@/lib/utils';
+import { formatEventDate, isOrderPickupEvent, toCommunity } from '@/lib/utils';
 import Image from 'next/image';
 import { useState } from 'react';
 import styles from './style.module.scss';
@@ -34,6 +34,7 @@ const EventCard = ({
         ...event,
       }
     : event;
+  const community = toCommunity(committee);
 
   const [expanded, setExpanded] = useState(false);
   const hasModal = !isOrderPickupEvent(event) || event.linkedEvent;
@@ -62,9 +63,6 @@ const EventCard = ({
         disabled={!hasModal}
       >
         <div className={styles.image}>
-          {!isOrderPickupEvent(event) && (
-            <PointsDisplay points={event.pointValue} attended={attended} />
-          )}
           <Image
             src={displayCover}
             alt="Event Cover Image"
@@ -75,29 +73,37 @@ const EventCard = ({
         </div>
         {!hideInfo && (
           <div className={styles.info}>
-            <div className={styles.header}>
-              <CommunityLogo community={committee ?? 'General'} size={50} />
-              <div className={styles.eventDetails}>
-                <Typography
-                  variant="body/medium"
-                  style={{ fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis' }}
-                >
-                  {title}
-                </Typography>
-                <Typography
-                  variant="body/small"
-                  style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
-                  suppressHydrationWarning
-                >
-                  {formatEventDate(start, end, showYear)}
-                </Typography>
-                <Typography
-                  variant="body/small"
-                  style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
-                >
-                  {location}
-                </Typography>
+            <Typography
+              variant="body/small"
+              style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+              suppressHydrationWarning
+            >
+              {formatEventDate(start, end, showYear)}
+            </Typography>
+            <Typography
+              variant="body/medium"
+              style={{ fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis' }}
+            >
+              {title}
+            </Typography>
+            <Typography
+              variant="body/small"
+              style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+            >
+              {location}
+            </Typography>
+            <div className={styles.badges}>
+              <div className={`${styles.badge} ${styles[`badge${community}`]}`}>
+                {communityNames[community]}
               </div>
+              {!isOrderPickupEvent(event) && (
+                <div className={`${styles.badge} ${styles.badgePoints}`}>
+                  {event.pointValue} point{event.pointValue === 1 ? '' : 's'}
+                </div>
+              )}
+              {!isOrderPickupEvent(event) && attended && (
+                <div className={`${styles.badge} ${styles.badgeAttended}`}>Attended</div>
+              )}
             </div>
           </div>
         )}

--- a/src/components/events/EventCard/index.tsx
+++ b/src/components/events/EventCard/index.tsx
@@ -48,7 +48,7 @@ const EventCard = ({
 
   return (
     <>
-      {hasModal && (
+      {hasModal ? (
         <EventModal
           open={expanded}
           attended={attended}
@@ -59,7 +59,7 @@ const EventCard = ({
           }
           onClose={() => setExpanded(false)}
         />
-      )}
+      ) : null}
 
       <button
         type="button"
@@ -76,7 +76,7 @@ const EventCard = ({
             fill
           />
         </div>
-        {!hideInfo && (
+        {!hideInfo ? (
           <div className={styles.info}>
             <Typography
               variant="body/small"
@@ -101,17 +101,17 @@ const EventCard = ({
               <div className={`${styles.badge} ${styles[`badge${community}`]}`}>
                 {communityNames[community]}
               </div>
-              {!isOrderPickupEvent(event) && (
+              {!isOrderPickupEvent(event) ? (
                 <div className={`${styles.badge} ${styles.badgePoints}`}>
                   {event.pointValue} point{event.pointValue === 1 ? '' : 's'}
                 </div>
-              )}
-              {!isOrderPickupEvent(event) && attended && (
+              ) : null}
+              {!isOrderPickupEvent(event) && attended ? (
                 <div className={`${styles.badge} ${styles.badgeAttended}`}>Attended</div>
-              )}
+              ) : null}
             </div>
           </div>
-        )}
+        ) : null}
       </button>
     </>
   );

--- a/src/components/events/EventCard/style.module.scss
+++ b/src/components/events/EventCard/style.module.scss
@@ -1,6 +1,7 @@
+@use 'src/styles/vars.scss' as vars;
+
 .container {
   background: transparent;
-  border: 1px solid var(--theme-primary-6);
   border-radius: 10px;
   height: fit-content;
   -ms-overflow-style: none;
@@ -11,13 +12,13 @@
   transition: all 0.3s;
   width: 20rem;
 
-  &.bordered { 
-    border: 1px solid var(--theme-primary-6);
+  &.bordered {
+    border: 1px solid var(--theme-card-outline);
     border-radius: 10px;
   }
 
   &:not([disabled]):hover {
-    box-shadow: 0 0 8px var(--theme-primary-6);
+    box-shadow: 0 3px 10px var(--theme-shadow);
     transform: scale(1.025);
   }
 
@@ -36,18 +37,54 @@
   .info {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 5px;
     padding: 1rem;
 
-    .header {
-      align-items: center;
+    .badges {
       display: flex;
-      flex-direction: row;
-      gap: 0.5rem;
+      flex-wrap: wrap;
+      gap: 0.25rem;
 
-      .eventDetails {
-        overflow: hidden;
-        white-space: nowrap;
+      .badge {
+        border: 1px solid transparent;
+        border-radius: 0.25rem;
+        font-size: 10px;
+        padding: 2px 5px;
+
+        &.badgeGeneral {
+          background-color: vars.$blue-3;
+          border-color: vars.$blue-5;
+        }
+
+        &.badgeAi {
+          background-color: vars.$scarlet-2;
+          border-color: vars.$scarlet-4;
+        }
+
+        &.badgeHack {
+          background-color: vars.$orange-3;
+          border-color: vars.$orange-5;
+        }
+
+        &.badgeCyber {
+          background-color: vars.$cyan-2;
+          border-color: vars.$cyan-5;
+        }
+
+        &.badgeDesign {
+          background-color: vars.$pink-2;
+          border-color: vars.$pink-4;
+        }
+
+        &.badgePoints {
+          background-color: #e4e4e4;
+          border-color: vars.$gray-4;
+        }
+
+        &.badgeAttended {
+          background-color: #b6e0ba;
+          border-color: vars.$success-1;
+        }
       }
     }
   }

--- a/src/components/events/EventCard/style.module.scss
+++ b/src/components/events/EventCard/style.module.scss
@@ -37,9 +37,15 @@
   .info {
     display: flex;
     flex-direction: column;
-    gap: 5px;
-    padding: 1rem;
+    gap: 6px;
+    padding: 1rem 1.5rem;
     white-space: nowrap;
+
+    .infoText {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
 
     .badges {
       display: flex;
@@ -51,6 +57,7 @@
         border-radius: 0.25rem;
         color: #000;
         font-size: 10px;
+        font-weight: 500;
         padding: 2px 5px;
 
         &.badgeGeneral {

--- a/src/components/events/EventCard/style.module.scss
+++ b/src/components/events/EventCard/style.module.scss
@@ -48,6 +48,7 @@
       .badge {
         border: 1px solid transparent;
         border-radius: 0.25rem;
+        color: #000;
         font-size: 10px;
         padding: 2px 5px;
 

--- a/src/components/events/EventCard/style.module.scss
+++ b/src/components/events/EventCard/style.module.scss
@@ -39,6 +39,7 @@
     flex-direction: column;
     gap: 5px;
     padding: 1rem;
+    white-space: nowrap;
 
     .badges {
       display: flex;

--- a/src/components/events/EventCard/style.module.scss.d.ts
+++ b/src/components/events/EventCard/style.module.scss.d.ts
@@ -12,6 +12,7 @@ export type Styles = {
   container: string;
   image: string;
   info: string;
+  infoText: string;
 };
 
 export type ClassNames = keyof Styles;

--- a/src/components/events/EventCard/style.module.scss.d.ts
+++ b/src/components/events/EventCard/style.module.scss.d.ts
@@ -1,8 +1,15 @@
 export type Styles = {
+  badge: string;
+  badgeAi: string;
+  badgeAttended: string;
+  badgeCyber: string;
+  badgeDesign: string;
+  badgeGeneral: string;
+  badgeHack: string;
+  badgePoints: string;
+  badges: string;
   bordered: string;
   container: string;
-  eventDetails: string;
-  header: string;
   image: string;
   info: string;
 };

--- a/src/components/store/OrderCard/style.module.scss
+++ b/src/components/store/OrderCard/style.module.scss
@@ -34,10 +34,10 @@
 }
 
 .orderStatus {
-  background: vars.$gray-400;
-  border: 1px solid vars.$gray-900;
+  background: vars.$gray-2;
+  border: 1px solid vars.$gray-7;
   border-radius: 0.875rem;
-  color: vars.$gray-900;
+  color: vars.$gray-7;
   margin-right: 1rem;
   padding: 0.25rem 0.5rem;
 
@@ -54,9 +54,9 @@
   }
 
   &.gray {
-    background: vars.$gray-400;
-    border: 1px solid vars.$gray-900;
-    color: vars.$gray-900;
+    background: vars.$gray-2;
+    border: 1px solid vars.$gray-7;
+    color: vars.$gray-7;
   }
 
   &.blue {

--- a/src/components/store/PickupEventPicker/style.module.scss
+++ b/src/components/store/PickupEventPicker/style.module.scss
@@ -5,15 +5,24 @@
 
   .window {
     --width: 320px;
-    height: 270px;
+    height: 300px;
     overflow: hidden;
     position: relative;
     width: var(--width);
 
     .slider {
       display: flex;
+      height: fit-content;
       position: absolute;
       transition: transform 0.3s ease-in-out;
+
+      > button {
+        border-radius: 0;
+
+        &:hover {
+          transform: unset;
+        }
+      }
     }
 
     .noEvents {
@@ -22,7 +31,7 @@
       display: flex;
       height: 100%;
       text-align: center;
-      width: 100%
+      width: 100%;
     }
   }
 

--- a/src/lib/constants/communities.ts
+++ b/src/lib/constants/communities.ts
@@ -16,9 +16,9 @@ export const communityLogos: Record<Community, StaticImageData> = {
 };
 
 export const communityNames: Record<Community, string> = {
-  Ai: 'ACM AI',
-  Cyber: 'ACM Cyber',
-  Design: 'ACM Design',
-  Hack: 'ACM Hack',
-  General: 'ACM',
+  Ai: 'AI',
+  Cyber: 'Cyber',
+  Design: 'Design',
+  Hack: 'Hack',
+  General: 'General',
 };

--- a/src/lib/constants/communities.ts
+++ b/src/lib/constants/communities.ts
@@ -8,9 +8,17 @@ import ACMLogo from '@/public/assets/acm-logos/general/light-mode.png';
 import type { StaticImageData } from 'next/image';
 
 export const communityLogos: Record<Community, StaticImageData> = {
-  AI: AILogo,
+  Ai: AILogo,
   Cyber: CyberLogo,
   Design: DesignLogo,
   Hack: HackLogo,
   General: ACMLogo,
+};
+
+export const communityNames: Record<Community, string> = {
+  Ai: 'ACM AI',
+  Cyber: 'ACM Cyber',
+  Design: 'ACM Design',
+  Hack: 'ACM Hack',
+  General: 'ACM',
 };

--- a/src/lib/types/enums.ts
+++ b/src/lib/types/enums.ts
@@ -7,7 +7,7 @@ export enum CookieType {
 
 export enum Community {
   HACK = 'Hack',
-  AI = 'AI',
+  AI = 'Ai',
   CYBER = 'Cyber',
   DESIGN = 'Design',
   GENERAL = 'General',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,6 +16,7 @@ import type {
   ValidatorError,
 } from '@/lib/types/apiResponses';
 import { ClientCartItem } from '@/lib/types/client';
+import { Community } from '@/lib/types/enums';
 import NoImage from '@/public/assets/graphics/cat404.png';
 import { AxiosError } from 'axios';
 import {
@@ -416,4 +417,13 @@ export const getOrderItemQuantities = (items: PublicOrderItem[]): PublicOrderIte
   });
 
   return Array.from(itemMap.values());
+};
+
+/** Normalizes string as a capitalized community name. Defaults to General. */
+export const toCommunity = (community = ''): Community => {
+  const formattedName = capitalize(community) as Community;
+
+  if (Object.values(Community).includes(formattedName)) return formattedName;
+
+  return Community.GENERAL;
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,7 +11,7 @@ import type { AppProps } from 'next/app';
 import { DM_Sans as DMSans } from 'next/font/google';
 import { ToastContainer } from 'react-toastify';
 
-const dmSans = DMSans({ subsets: ['latin'], weight: ['400', '500', '700'] });
+const dmSans = DMSans({ subsets: ['latin'], weight: ['400', '500', '600', '700'] });
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/src/styles/themes.scss
+++ b/src/styles/themes.scss
@@ -32,6 +32,7 @@
   --theme-accent-line-1-transparent: #{vars.$light-accent-line-1-transparent}; // light accent lines
   --theme-accent-line-2-transparent: #{vars.$light-accent-line-2-transparent}; // light accent lines
   --theme-shadow: #{vars.$light-accent-line-2-transparent};
+  --theme-card-outline: #{vars.$light-text-on-background-3}; // event card outline
 
   --theme-text-on-background-1: #{vars.$light-text-on-background-1}; // text on primary titles and input borders
   --theme-text-on-background-2: #{vars.$light-text-on-background-2}; // text on primary subtitles (LVL, Dates)
@@ -80,6 +81,7 @@
   --theme-accent-line-1-transparent: #{vars.$dark-accent-line-1-transparent}; // dark accent lines
   --theme-accent-line-2-transparent: #{vars.$dark-accent-line-2-transparent}; // dark accent lines
   --theme-shadow: #{vars.$dark-accent-line-1-transparent};
+  --theme-card-outline: #{vars.$dark-surface-1}; // event card outline
 
   --theme-text-on-background-1: #{vars.$dark-text-on-background-1}; // text on primary titles and input borders
   --theme-text-on-background-2: #{vars.$dark-text-on-background-2}; // text on primary subtitles (LVL, Dates)

--- a/src/styles/vars.scss
+++ b/src/styles/vars.scss
@@ -95,6 +95,13 @@ $dark-text-on-surface-2: #fff;
 /*
  * Communities
 */
+// General
+$blue-1: #ebf5ff;
+$blue-2: #cce5ff;
+$blue-3: #a8d3ff;
+$blue-4: #85c2ff;
+$blue-5: #62b0ff;
+
 // Hack
 $orange-1: #fff2e6;
 $orange-2: #ffe4c9;
@@ -150,15 +157,13 @@ $blue-100: #cce5ff;
 
 $white: #fff;
 
-$gray-100: #fafafa;
-$gray-200: #f4f4f4;
-$gray-300: #f8f8f8;
-$gray-400: #e4e4e4;
-$gray-500: #c4c4c4;
-$gray-600: #979797;
-$gray-700: #525252;
-$gray-800: #37393e;
-$gray-900: #2e3036;
+$gray-1: #f3f3f3;
+$gray-2: #ebebeb;
+$gray-3: #d8d8d8;
+$gray-4: #b4b4b4;
+$gray-5: #909090;
+$gray-6: #6c6c6c;
+$gray-7: #484848;
 
 $black: #000000d9;
 


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

Closes #162 

<!-- If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak. -->

updated event card design

did not touch event details modal, so `PointsDisplay` and `CommunityLogo` are still in use

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

## Changes

- event card design
- I changed the `Community.AI` enum value to `Ai`. The enum was only used for `CommunityLogo`. There are two reasons for this
  - `CommunityLogo` currently uses `capitalize` to normalize ACM communities, but this would turn `AI` into `Ai`
  - For some reason, our `.scss.d.ts` generator turns `.badgeAI` into `.badgeAi`. I have no idea why

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [x] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->

![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/f4f98d72-fd18-4e5b-b276-8aa8db00ca99)


![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/9b109e01-7f38-4549-8923-8cb4abb4e982)
