### PR TITLE
Tab titles

### DIFF
--- a/src/components/admin/event/AdminPickupEvent/style.module.scss
+++ b/src/components/admin/event/AdminPickupEvent/style.module.scss
@@ -10,6 +10,16 @@
   h1 {
     font-size: 2rem;
   }
+
+  .viewPage {
+    background-color: var(--theme-primary-2);
+    border-radius: 0.5rem;
+    color: var(--theme-background);
+    display: flex;
+    font-weight: bold;
+    gap: 0.5rem;
+    padding: 0.5rem;
+  }
 }
 
 .form {

--- a/src/components/admin/event/AdminPickupEvent/style.module.scss.d.ts
+++ b/src/components/admin/event/AdminPickupEvent/style.module.scss.d.ts
@@ -3,6 +3,7 @@ export type Styles = {
   form: string;
   header: string;
   submitButtons: string;
+  viewPage: string;
 };
 
 export type ClassNames = keyof Styles;

--- a/src/components/admin/event/AdminPickupEvent/style.module.scss.d.ts
+++ b/src/components/admin/event/AdminPickupEvent/style.module.scss.d.ts
@@ -1,11 +1,8 @@
 export type Styles = {
-  addImage: string;
   defaultThemeColorHex: string;
   form: string;
   header: string;
-  photos: string;
   submitButtons: string;
-  viewPage: string;
 };
 
 export type ClassNames = keyof Styles;

--- a/src/components/common/SEO/index.tsx
+++ b/src/components/common/SEO/index.tsx
@@ -1,17 +1,24 @@
 import Logo from '@/public/assets/acm-logos/general/light-mode.png';
 import Head from 'next/head';
 
-const SEO = () => {
-  const TITLE = 'ACM UCSD Membership Portal';
-  const DESC =
-    'Meet new friends, discover exciting events, and earn points for free ACM swag! Create an account today to find your community!';
+const TITLE = 'ACM UCSD Membership Portal';
+const DESC =
+  'Meet new friends, discover exciting events, and earn points for free ACM swag! Create an account today to find your community!';
+
+interface SEOProps {
+  title?: string;
+  description?: string;
+}
+
+const SEO = ({ title, description = DESC }: SEOProps) => {
+  const fullTitle = title ? `${title} · ${TITLE}` : TITLE;
 
   return (
     <Head>
       {/* google indexing data */}
 
-      <title>{TITLE}</title>
-      <meta name="description" content={DESC} />
+      <title>{fullTitle}</title>
+      <meta name="description" content={description} />
       <link rel="shortcut icon" href="/favicon.ico" />
 
       {/* link sharing data */}
@@ -23,11 +30,11 @@ const SEO = () => {
       {/* actual website title */}
       <meta property="og:site_name" content="ACM at UCSD" />
       {/* title to display for the specific link being shared */}
-      <meta property="og:title" content={TITLE} />
+      <meta property="og:title" content={fullTitle} />
       {/* preview image */}
       <meta property="og:image" content={Logo.src} />
       {/* preview description text */}
-      <meta property="og:description" content={DESC} />
+      <meta property="og:description" content={description} />
     </Head>
   );
 };

--- a/src/components/common/SEO/index.tsx
+++ b/src/components/common/SEO/index.tsx
@@ -11,7 +11,7 @@ interface SEOProps {
 }
 
 const SEO = ({ title, description = DESC }: SEOProps) => {
-  const fullTitle = title ? `${title} · ${TITLE}` : TITLE;
+  const fullTitle = title ? `${title} | ${TITLE}` : TITLE;
 
   return (
     <Head>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,7 +22,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           font-family: ${dmSans.style.fontFamily}, sans-serif;
         }
       `}</style>
-      <SEO />
+      <SEO title={pageProps.title} description={pageProps.description} />
       <ThemeProvider>
         <ToastContainer />
         <PageLayout accessType={pageProps?.user?.accessType}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,7 +13,14 @@ import { ToastContainer } from 'react-toastify';
 
 const dmSans = DMSans({ subsets: ['latin'], weight: ['400', '500', '600', '700'] });
 
-export default function MyApp({ Component, pageProps }: AppProps) {
+export default function MyApp({ Component, pageProps, router }: AppProps) {
+  let { title } = pageProps;
+  if (router.pathname === '/404') {
+    title = '404';
+  } else if (router.pathname === '/500') {
+    title = '500';
+  }
+
   return (
     <>
       <style jsx global>{`
@@ -22,7 +29,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           font-family: ${dmSans.style.fontFamily}, sans-serif;
         }
       `}</style>
-      <SEO title={pageProps.title} description={pageProps.description} />
+      <SEO title={title} description={pageProps.description} />
       <ThemeProvider>
         <ToastContainer />
         <PageLayout accessType={pageProps?.user?.accessType}>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -66,7 +66,7 @@ const AboutPage = () => {
 export default AboutPage;
 
 const getServerSidePropsFunc: GetServerSideProps = async () => ({
-  props: {},
+  props: { title: 'About ACM@UCSD' },
 });
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -66,7 +66,7 @@ const AboutPage = () => {
 export default AboutPage;
 
 const getServerSidePropsFunc: GetServerSideProps = async () => ({
-  props: { title: 'About ACM@UCSD' },
+  props: { title: 'About ACM @ UCSD' },
 });
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/admin/attendance.tsx
+++ b/src/pages/admin/attendance.tsx
@@ -79,7 +79,10 @@ const AwardPointsPage: NextPage = () => {
 export default AwardPointsPage;
 
 const getServerSidePropsFunc: GetServerSideProps = async () => ({
-  props: {},
+  props: {
+    title: 'Retroactive Attendance',
+    description: 'Mark members as attended for past events',
+  },
 });
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/admin/event/create.tsx
+++ b/src/pages/admin/event/create.tsx
@@ -21,11 +21,11 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res, query }) =
   if (typeof query.duplicate === 'string') {
     const defaultData = await EventAPI.getEvent(query.duplicate, token);
     return {
-      props: { defaultData },
+      props: { title: 'Create Event', defaultData },
     };
   }
   return {
-    props: { defaultData: {} },
+    props: { title: 'Create Event', defaultData: {} },
   };
 };
 

--- a/src/pages/admin/event/edit/[uuid].tsx
+++ b/src/pages/admin/event/edit/[uuid].tsx
@@ -32,9 +32,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ params, req, res }) 
   try {
     const editEvent = await EventAPI.getEvent(uuid, token);
     return {
-      props: {
-        editEvent,
-      },
+      props: { title: `Edit ${editEvent.title}`, editEvent },
     };
   } catch (err: any) {
     return { redirect: { destination: config.admin.homeRoute, permanent: false } };

--- a/src/pages/admin/event/index.tsx
+++ b/src/pages/admin/event/index.tsx
@@ -87,7 +87,7 @@ const getServerSidePropsFunc: GetServerSideProps = async () => {
   ]);
 
   return {
-    props: { allEvents, pastEvents, futureEvents },
+    props: { title: 'Manage Events', allEvents, pastEvents, futureEvents },
   };
 };
 

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -103,7 +103,7 @@ export default AdminPage;
 const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
   const preview =
     CookieService.getServerCookie(CookieType.USER_PREVIEW_ENABLED, { req, res }) ?? '';
-  return { props: { preview } };
+  return { props: { title: 'Admin Actions', preview } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/admin/milestone.tsx
+++ b/src/pages/admin/milestone.tsx
@@ -64,7 +64,10 @@ const AwardPointsPage: NextPage = () => {
 export default AwardPointsPage;
 
 const getServerSidePropsFunc: GetServerSideProps = async () => ({
-  props: {},
+  props: {
+    title: 'Create Milestone',
+    description: "Award points to all active users (e.g. for ACM's 8 year anniversary)",
+  },
 });
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/admin/points.tsx
+++ b/src/pages/admin/points.tsx
@@ -76,7 +76,7 @@ const AwardPointsPage: NextPage = () => {
 export default AwardPointsPage;
 
 const getServerSidePropsFunc: GetServerSideProps = async () => ({
-  props: { title: 'Award Bonus Points', description: 'Grant Bonus Points to a Specific User' },
+  props: { title: 'Award Bonus Points', description: 'Grant bonus points to a specific user' },
 });
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/admin/points.tsx
+++ b/src/pages/admin/points.tsx
@@ -76,7 +76,7 @@ const AwardPointsPage: NextPage = () => {
 export default AwardPointsPage;
 
 const getServerSidePropsFunc: GetServerSideProps = async () => ({
-  props: {},
+  props: { title: 'Award Bonus Points', description: 'Grant Bonus Points to a Specific User' },
 });
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/admin/store/pickup/[uuid].tsx
+++ b/src/pages/admin/store/pickup/[uuid].tsx
@@ -110,9 +110,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ params, req, res }) 
         return aName.localeCompare(bName);
       });
     return {
-      props: {
-        pickupEvent,
-      },
+      props: { title: pickupEvent.title, pickupEvent },
     };
   } catch (e) {
     return { notFound: true };

--- a/src/pages/admin/store/pickup/create.tsx
+++ b/src/pages/admin/store/pickup/create.tsx
@@ -34,7 +34,7 @@ export default CreatePickupEventPage;
 const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
   const token = CookieService.getServerCookie(CookieType.ACCESS_TOKEN, { req, res });
   const futureEvents = await EventAPI.getAllFutureEvents();
-  return { props: { token, futureEvents } };
+  return { props: { title: 'Create Pickup Event', token, futureEvents } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/admin/store/pickup/edit/[uuid].tsx
+++ b/src/pages/admin/store/pickup/edit/[uuid].tsx
@@ -45,7 +45,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ params, req, res }) 
     EventAPI.getAllFutureEvents(),
     StoreAPI.getPickupEvent(token, uuid),
   ]);
-  return { props: { token, futureEvents, pickupEvent } };
+  return { props: { title: `Edit ${pickupEvent.title}`, token, futureEvents, pickupEvent } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/admin/store/pickup/index.tsx
+++ b/src/pages/admin/store/pickup/index.tsx
@@ -70,7 +70,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
     futurePickupEventsPromise,
     pastPickupEventsPromise,
   ]);
-  return { props: { futurePickupEvents, pastPickupEvents } };
+  return { props: { title: 'Manage Pickup Events', futurePickupEvents, pastPickupEvents } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/check-email.tsx
+++ b/src/pages/check-email.tsx
@@ -49,8 +49,6 @@ export const getServerSideProps: GetServerSideProps = async ({ query }) => {
     };
   }
   return {
-    props: {
-      email,
-    },
+    props: { title: 'Verify your email address', email },
   };
 };

--- a/src/pages/debug.tsx
+++ b/src/pages/debug.tsx
@@ -55,7 +55,7 @@ const getServerSidePropsFunc: GetServerSideProps = async () => {
       notFound: true,
     };
 
-  return { props: {} };
+  return { props: { title: 'Debug' } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/discord.tsx
+++ b/src/pages/discord.tsx
@@ -9,7 +9,7 @@ const DiscordPage = () => {
 export default DiscordPage;
 
 const getServerSidePropsFunc: GetServerSideProps = async () => ({
-  props: {},
+  props: { title: 'Discord' },
 });
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -179,7 +179,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
 
   const [events, attendances] = await Promise.all([getEventsPromise, getAttendancesPromise]);
 
-  return { props: { events, attendances } };
+  return { props: { title: 'Events', events, attendances } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/forgot-password.tsx
+++ b/src/pages/forgot-password.tsx
@@ -5,7 +5,7 @@ import { AuthManager } from '@/lib/managers';
 import { ValidationService } from '@/lib/services';
 import type { SendPasswordResetEmailRequest } from '@/lib/types/apiRequests';
 import { reportError } from '@/lib/utils';
-import type { NextPage } from 'next';
+import type { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { AiOutlineMail } from 'react-icons/ai';
@@ -60,3 +60,7 @@ const ForgotPassword: NextPage = () => {
 };
 
 export default ForgotPassword;
+
+export const getServerSideProps: GetServerSideProps = async () => ({
+  props: { title: 'Forgot Password' },
+});

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -178,7 +178,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res, query }) =
   const leaderboard = await LeaderboardAPI.getLeaderboard(AUTH_TOKEN, getLeaderboardRange(sort));
 
   return {
-    props: { sort, leaderboard },
+    props: { title: 'Leaderboard', sort, leaderboard },
   };
 };
 

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -568,7 +568,7 @@ const getServerSidePropsFunc: GetServerSideProps<EditProfileProps> = async ({ re
   // Ensure `user` is up-to-date
   const user = await UserAPI.getCurrentUserAndRefreshCookie(AUTH_TOKEN, { req, res });
 
-  return { props: { authToken: AUTH_TOKEN, user } };
+  return { props: { title: 'Edit Profile', authToken: AUTH_TOKEN, user } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -6,7 +6,7 @@ import { ValidationService } from '@/lib/services';
 import type { UserRegistration } from '@/lib/types/apiRequests';
 import type { PrivateProfile } from '@/lib/types/apiResponses';
 import { getNextNYears, reportError } from '@/lib/utils';
-import type { NextPage } from 'next';
+import type { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { AiOutlineMail } from 'react-icons/ai';
@@ -176,3 +176,7 @@ const RegisterPage: NextPage = () => {
 };
 
 export default RegisterPage;
+
+export const getServerSideProps: GetServerSideProps = async () => ({
+  props: { title: 'Become a Member' },
+});

--- a/src/pages/reset-password/[accessCode].tsx
+++ b/src/pages/reset-password/[accessCode].tsx
@@ -97,8 +97,6 @@ export default ResetPasswordPage;
 export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   const code = params?.accessCode as string;
   return {
-    props: {
-      code,
-    },
+    props: { title: 'Reset Password', code },
   };
 };

--- a/src/pages/store/cart.tsx
+++ b/src/pages/store/cart.tsx
@@ -262,6 +262,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
 
   return {
     props: {
+      title: 'Cart',
       user,
       savedCart,
       pickupEvents,

--- a/src/pages/store/collection/[uuid].tsx
+++ b/src/pages/store/collection/[uuid].tsx
@@ -97,6 +97,8 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ params, req, res }) 
     const collection = await StoreAPI.getCollection(token, uuid);
     return {
       props: {
+        title: collection.title,
+        description: collection.description,
         uuid,
         collection,
         previewPublic: preview === 'member',

--- a/src/pages/store/collection/[uuid]/edit.tsx
+++ b/src/pages/store/collection/[uuid]/edit.tsx
@@ -12,13 +12,13 @@ import { GetServerSideProps } from 'next';
 interface CollectionEditPageProps {
   user: PrivateProfile;
   token: string;
-  item: PublicMerchCollection;
+  collection: PublicMerchCollection;
 }
-const CollectionEditPage = ({ user: { credits }, token, item }: CollectionEditPageProps) => {
+const CollectionEditPage = ({ user: { credits }, token, collection }: CollectionEditPageProps) => {
   return (
     <div className={styles.container}>
       <Navbar balance={credits} showBack />
-      <CollectionDetailsForm mode="edit" defaultData={item} token={token} />
+      <CollectionDetailsForm mode="edit" defaultData={collection} token={token} />
     </div>
   );
 };
@@ -30,8 +30,8 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ params, req, res }) 
   const token = CookieService.getServerCookie(CookieType.ACCESS_TOKEN, { req, res });
 
   try {
-    const item = await StoreAPI.getCollection(token, uuid);
-    return { props: { token, item } };
+    const collection = await StoreAPI.getCollection(token, uuid);
+    return { props: { title: `Edit ${collection.title}`, token, collection } };
   } catch {
     return { notFound: true };
   }

--- a/src/pages/store/collection/new.tsx
+++ b/src/pages/store/collection/new.tsx
@@ -31,7 +31,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res, query }) =
     typeof query.duplicate === 'string'
       ? await StoreAPI.getCollection(token, query.duplicate)
       : null;
-  return { props: { token, item } };
+  return { props: { title: 'Create Collection', token, item } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/store/index.tsx
+++ b/src/pages/store/index.tsx
@@ -150,6 +150,9 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res, query }) =
 
   return {
     props: {
+      title: 'The ACM Store',
+      description:
+        'Shop the ACM Store for exclusive ACM merchandise including shirts, hoodies, pop sockets & more!',
       view: query.view === 'all' ? 'all-items' : 'collections',
       collections,
       previewPublic: preview === 'member',

--- a/src/pages/store/item/[uuid].tsx
+++ b/src/pages/store/item/[uuid].tsx
@@ -139,6 +139,8 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ params, req, res }) 
     const item = await StoreAPI.getItem(token, uuid);
     return {
       props: {
+        title: item.itemName,
+        description: item.description,
         uuid,
         item,
         previewPublic: preview === 'member',

--- a/src/pages/store/item/[uuid]/edit.tsx
+++ b/src/pages/store/item/[uuid]/edit.tsx
@@ -35,7 +35,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ params, req, res }) 
       StoreAPI.getItem(token, uuid),
       StoreAPI.getAllCollections(token),
     ]);
-    return { props: { token, item, collections } };
+    return { props: { title: `Edit ${item.itemName}`, token, item, collections } };
   } catch {
     return { notFound: true };
   }

--- a/src/pages/store/item/new.tsx
+++ b/src/pages/store/item/new.tsx
@@ -39,7 +39,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res, query }) =
       : query.collection ?? null,
     StoreAPI.getAllCollections(token),
   ]);
-  return { props: { token, item, collections } };
+  return { props: { title: 'Create Store Item', token, item, collections } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/store/orders.tsx
+++ b/src/pages/store/orders.tsx
@@ -81,7 +81,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
 
   orders.sort((a, b) => new Date(b.orderedAt).getTime() - new Date(a.orderedAt).getTime());
 
-  return { props: { orders, futurePickupEvents } };
+  return { props: { title: 'My Orders', orders, futurePickupEvents } };
 };
 
 export const getServerSideProps = withAccessType(

--- a/src/pages/u/[handle].tsx
+++ b/src/pages/u/[handle].tsx
@@ -55,6 +55,7 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ params, req, res }) 
     // render UserProfilePage
     return {
       props: {
+        title: `${handleUser.firstName} ${handleUser.lastName}`,
         handleUser,
         isSignedInUser,
         signedInAttendances,

--- a/src/pages/verify-email/[accessCode].tsx
+++ b/src/pages/verify-email/[accessCode].tsx
@@ -65,12 +65,14 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
 
     return {
       props: {
+        title: 'Email Verification',
         status: true,
       },
     };
   } catch (err: any) {
     return {
       props: {
+        title: 'Email Verification',
         status: false,
       },
     };


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

this doesnt fix an issue

<!-- If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak. -->

it was a bit annoying trying to find a page in my browser history on the current membership portal. giving each page a title 

Since we're using Next.JS and SSR, we benefit from being able to set the page title/description on the server side, so they can show up in the website previews on Discord. not that it really matters since pretty much every page

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

## Changes

- `_app` now takes a `title` and `description` component, which will be passed to `SEO` to set the page title/description. `| ACM UCSD Membership Portal` gets appended to the end of these titles, if specified (but maybe we could shorten these to just `Page Title | ACM`?)
- added titles to every page except for the home page and login page

# Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->

![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/22133785/465e20f8-33f0-4c04-818e-f54a27e2fe79)
