### PR TITLE
Right align

### DIFF
--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -116,6 +116,7 @@ const LeaderboardPage = ({ sort, leaderboard, user: { uuid } }: LeaderboardProps
             setPage(0);
             setScrollIntoView(0);
           }}
+          className={styles.timeDropdown}
         />
       </div>
       {topThreeUsers.length > 0 ? (

--- a/src/styles/pages/leaderboard.module.scss
+++ b/src/styles/pages/leaderboard.module.scss
@@ -64,6 +64,10 @@
         color: var(--theme-text-on-background-3);
       }
     }
+
+    .timeDropdown select {
+      text-align: right;
+    }
   }
 
   .topThreeContainer {

--- a/src/styles/pages/leaderboard.module.scss.d.ts
+++ b/src/styles/pages/leaderboard.module.scss.d.ts
@@ -5,6 +5,7 @@ export type Styles = {
   leaderboard: string;
   myPosition: string;
   search: string;
+  timeDropdown: string;
   topThreeContainer: string;
 };
 


### PR DESCRIPTION
# Info
Past year dropdown option looks weird with uneven space on the right side of it

## Changes

- [Fill in here]

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [ ] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [ ] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->
