### PR TITLE
Implement scrolling text

### DIFF
--- a/src/components/common/ScrollingText/index.tsx
+++ b/src/components/common/ScrollingText/index.tsx
@@ -1,0 +1,34 @@
+import { CSSProperties, PropsWithChildren, useEffect, useState } from 'react';
+import styles from './style.module.scss';
+
+// scroll speed in px per second
+const VELOCITY = 50;
+
+/**
+ * Make text scroll when it overflows.
+ */
+const ScrollingText = ({ children }: PropsWithChildren) => {
+  const [overflowAmount, setOverflowAmount] = useState(1);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [contentWidth, setContentWidth] = useState(0);
+
+  useEffect(() => setOverflowAmount(contentWidth - containerWidth), [contentWidth, containerWidth]);
+
+  return (
+    <div
+      ref={node => setContainerWidth(node?.offsetWidth ?? 0)}
+      className={overflowAmount > 0 ? styles.overflowing : ''}
+      // calculate animation time accounting for 2rem gap
+      style={{ '--anim-time': `${(contentWidth + 32) / VELOCITY}s` } as CSSProperties}
+    >
+      <div className={styles.window}>
+        <div className={styles.slider}>
+          <div ref={node => setContentWidth(node?.offsetWidth ?? 0)}>{children}</div>
+          {overflowAmount > 0 && <div>{children}</div>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ScrollingText;

--- a/src/components/common/ScrollingText/style.module.scss
+++ b/src/components/common/ScrollingText/style.module.scss
@@ -2,8 +2,8 @@
   position: relative;
 
   .window {
-    overflow: hidden;
     margin-right: 2px; // shift cutoff by 2px for antialiased text bleeding through
+    overflow: hidden;
 
     .slider {
       display: flex;
@@ -21,14 +21,14 @@
   }
 
   &::after {
-    position: absolute;
-    height: 100%;
-    width: 2rem;
-    top: 0;
-    right: 0;
-    content: "";
     background-image: linear-gradient(to left, var(--theme-background), rgba(0,0,0,0));
+    content: "";
+    height: 100%;
     pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 2rem;
   }
 }
 

--- a/src/components/common/ScrollingText/style.module.scss
+++ b/src/components/common/ScrollingText/style.module.scss
@@ -1,0 +1,37 @@
+.overflowing {
+  position: relative;
+
+  .window {
+    overflow: hidden;
+    margin-right: 2px; // shift cutoff by 2px for antialiased text bleeding through
+
+    .slider {
+      display: flex;
+      gap: 2rem;
+    
+      @keyframes marquee {
+        0%   { transform: translateX(0%); }
+        100% { transform: translateX(calc(-100% / 2 - 1rem)); }
+      }
+    
+      &:hover {
+        animation: marquee var(--anim-time, 3s) linear infinite;
+      }
+    }
+  }
+
+  &::after {
+    position: absolute;
+    height: 100%;
+    width: 2rem;
+    top: 0;
+    right: 0;
+    content: "";
+    background-image: linear-gradient(to left, var(--theme-background), rgba(0,0,0,0));
+    pointer-events: none;
+  }
+}
+
+.slider {
+  width: fit-content;
+}

--- a/src/components/common/ScrollingText/style.module.scss.d.ts
+++ b/src/components/common/ScrollingText/style.module.scss.d.ts
@@ -1,0 +1,12 @@
+export type Styles = {
+  marquee: string;
+  overflowing: string;
+  slider: string;
+  window: string;
+};
+
+export type ClassNames = keyof Styles;
+
+declare const styles: Styles;
+
+export default styles;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -9,6 +9,7 @@ export { default as LinkButton } from './LinkButton';
 export { default as Modal } from './Modal';
 export { default as PaginationControls } from './PaginationControls';
 export { default as SEO } from './SEO';
+export { default as ScrollingText } from './ScrollingText';
 export { default as Typography } from './Typography';
 export type { Variant } from './Typography';
 export { default as VerticalForm } from './VerticalForm';

--- a/src/components/events/EventCard/index.tsx
+++ b/src/components/events/EventCard/index.tsx
@@ -1,4 +1,5 @@
 import { Typography } from '@/components/common';
+import ScrollingText from '@/components/common/ScrollingText';
 import EventBadges from '@/components/events/EventBadges';
 import EventModal from '@/components/events/EventModal';
 import PickupEventPreviewModal from '@/components/store/PickupEventPreviewModal';
@@ -99,21 +100,16 @@ const EventCard = ({
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                 }}
-                suppressHydrationWarning
               >
-                {formatEventDate(start, end, showYear)}
+                <ScrollingText>
+                  <span suppressHydrationWarning>{formatEventDate(start, end, showYear)}</span>
+                </ScrollingText>
               </Typography>
-              <Typography
-                variant="body/medium"
-                style={{ fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis' }}
-              >
-                {title}
+              <Typography variant="body/medium" style={{ fontWeight: 700 }}>
+                <ScrollingText>{title}</ScrollingText>
               </Typography>
-              <Typography
-                variant="body/small"
-                style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
-              >
-                {location}
+              <Typography variant="body/small">
+                <ScrollingText>{location}</ScrollingText>
               </Typography>
             </div>
             <EventBadges event={event} attended={attended} />


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info


Implement scrolling text for event info that overflows the card

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

## Changes

- Implements the `ScrollingText` component that makes child text scroll on hover if it would overflow
- `EventCard` uses new scrolling text for each line

# Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/30709485/c65c8390-cb28-4a6f-b304-fe6187e1fd18)
^overflowing text fades out

![image](https://github.com/acmucsd/membership-portal-ui-v2/assets/30709485/4df63bd2-5620-421a-a664-fc1dc33f4dc0)
^mid scroll when title is hovered

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->
