### PR TITLE
Fix safe area color for ios iphone 15s

### DIFF
--- a/src/components/common/ThemeToggle/index.tsx
+++ b/src/components/common/ThemeToggle/index.tsx
@@ -29,7 +29,7 @@ const ThemeToggle = () => {
     // This affects the color of the safe zone on iPhone 15.
     const metaThemeColor = document.querySelector('meta[name="theme-color"]');
     if (metaThemeColor && resolvedTheme === 'dark') {
-      metaThemeColor.setAttribute('content', '#37393e');
+      metaThemeColor.setAttribute('content', '#25262b');
     } else if (metaThemeColor) {
       metaThemeColor.setAttribute('content', '#fff');
     }


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

Closes **[ISSUE NUMBER]**.

<!-- If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak. -->

- We have a special meta tag for the safe area in iPhone 15s (i.e. the area around the dynamic island)
  - The color for backgrounds was updated recently when moving to a new elevation, but safe area color wasn't updated, so I'm doing it here

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->
