### PR TITLE
Live tag - Fix animation flash on Safari

### DIFF
--- a/src/components/events/EventBadges/style.module.scss
+++ b/src/components/events/EventBadges/style.module.scss
@@ -34,11 +34,10 @@
       }
 
       &::before {
-        animation: pulse2 2s ease-in-out reverse infinite;
+        animation: pulse2 2s ease-out reverse infinite;
         border: 2px solid vars.$danger-1;
         border-radius: 5px;
         content: '';
-        opacity: 0;
         position: absolute;
 
         @keyframes pulse2 {

--- a/src/components/events/EventBadges/style.module.scss
+++ b/src/components/events/EventBadges/style.module.scss
@@ -23,29 +23,35 @@
         animation: pulse 1s ease-in-out infinite alternate;
 
         @keyframes pulse {
-          0% { opacity: 0 }
-          100% {opacity: 1 }
+          0% {
+            opacity: 0;
+          }
+
+          100% {
+            opacity: 1;
+          }
         }
       }
 
       &::before {
-        animation: pulse2 2s ease-out forwards infinite;
+        animation: pulse2 2s ease-in-out reverse infinite;
         border: 2px solid vars.$danger-1;
         border-radius: 5px;
         content: '';
+        opacity: 0;
         position: absolute;
 
         @keyframes pulse2 {
           0% {
-            filter: blur(0);
-            inset: 0;
-            opacity: 1;
-          }
-
-          100% {
             filter: blur(2px);
             inset: -0.75rem;
             opacity: 0;
+          }
+
+          100% {
+            filter: blur(0);
+            inset: 0;
+            opacity: 1;
           }
         }
       }


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

Fixing an animation bug where there were weird flashes for the live tag on Safari

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [x] on the live deployment preview on Desktop.
- [x] on the live deployment preview on Mobile.
- [x] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [ ] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->

after:
https://github.com/acmucsd/membership-portal-ui-v2/assets/27360825/80e42d9f-c0d1-4a84-8ae7-43af4355e027

