### PR TITLE
Filter out pickup events that start in less than 2 days

### DIFF
--- a/src/pages/store/cart.tsx
+++ b/src/pages/store/cart.tsx
@@ -254,6 +254,13 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
       .filter(
         event => !(event.orders && event.orderLimit && event.orders.length > event.orderLimit)
       )
+      // filter out events that have a start time less than 2 days from now
+      .filter(event => {
+        const startTime = new Date(event.start);
+        const now = new Date();
+        now.setDate(now.getDate() + 2);
+        return startTime >= now;
+      })
   );
   const userPromise = getCurrentUserAndRefreshCookie(AUTH_TOKEN, { req, res });
 

--- a/src/pages/store/cart.tsx
+++ b/src/pages/store/cart.tsx
@@ -257,9 +257,9 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
       // filter out events that have a start time less than 2 days from now
       .filter(event => {
         const startTime = new Date(event.start);
-        const now = new Date();
-        now.setDate(now.getDate() + 2);
-        return startTime >= now;
+        const now = Date.now();
+        const twoDaysFromNow = new Date(now + 2 * 24 * 60 * 60 * 1000);
+        return startTime >= twoDaysFromNow;
       })
   );
   const userPromise = getCurrentUserAndRefreshCookie(AUTH_TOKEN, { req, res });

--- a/src/pages/store/cart.tsx
+++ b/src/pages/store/cart.tsx
@@ -258,7 +258,8 @@ const getServerSidePropsFunc: GetServerSideProps = async ({ req, res }) => {
       .filter(event => {
         const startTime = new Date(event.start);
         const now = Date.now();
-        const twoDaysFromNow = new Date(now + 2 * 24 * 60 * 60 * 1000);
+        const twoDaysInMs = 2 * 24 * 60 * 60 * 1000;
+        const twoDaysFromNow = new Date(now + twoDaysInMs);
         return startTime >= twoDaysFromNow;
       })
   );


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

Closes #241

Filtered out pickup events that start less than 2 days from now, and hides them from the Cart page. There were some discussions around if they should be hidden or just prevent from being selected but ultimately we decided hiding.

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

## Changes

- filter

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [ ] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->
