### PR TITLE
Fix Safari Bugs on iOS

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -132,6 +132,9 @@ const PortalHomePage = ({
         <div className={styles.checkinButtons}>
           <input
             type="text"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
             placeholder="Enter event check-in code"
             className={styles.checkinInput}
             value={checkinCode}

--- a/src/styles/pages/Home.module.scss
+++ b/src/styles/pages/Home.module.scss
@@ -221,7 +221,8 @@
         width: 0;
 
         @media screen and (width <= vars.$breakpoint-md) {
-          font-size: 0.75rem;
+          // hardcoded to 16 to prevent auto zoom on iOS
+          font-size: 16px;
           line-height: 1.5rem;
           padding: 0.625rem 1.25rem;
         }

--- a/src/styles/pages/Home.module.scss
+++ b/src/styles/pages/Home.module.scss
@@ -221,8 +221,8 @@
         width: 0;
 
         @media screen and (width <= vars.$breakpoint-md) {
-          // hardcoded to 16 to prevent auto zoom on iOS
-          font-size: 16px;
+          // 1rem prevents auto zoom on iOS
+          font-size: 1rem;
           line-height: 1.5rem;
           padding: 0.625rem 1.25rem;
         }


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

There were some iOS Safari annoyances

- For the input to check in to an event, the text would autocorrect/autocomplete
- On iOS, the default behavior is to zoom in to a text input, but it doesn't zoom out afterwards

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

## Changes

- Some css and a few attributes for the input tag

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->
