### PR TITLE
Reordered checkout layout for store

### DIFF
--- a/src/components/store/PickupEventDropdown/index.tsx
+++ b/src/components/store/PickupEventDropdown/index.tsx
@@ -1,0 +1,44 @@
+import PickupEventDetail from '@/components/store/PickupEventDetail';
+import { Dropdown, Typography } from '@/components/common';
+import { PublicOrderPickupEvent } from '@/lib/types/apiResponses';
+import { formatEventDate } from '@/lib/utils';
+import styles from './style.module.scss';
+
+interface EventPickerProps {
+  events: PublicOrderPickupEvent[];
+  eventIndex: number;
+  setEventIndex: (...args: any[]) => any;
+}
+
+const PickupEventDropdown = ({ events, eventIndex, setEventIndex }: EventPickerProps) => {
+  return (
+    <div className={styles.eventPicker}>
+      {events.length > 0 ? (
+        <div className={styles.window}>
+          <PickupEventDetail pickupEvent={events[eventIndex] as PublicOrderPickupEvent} />
+          <Dropdown
+            className={styles.dropdown}
+            name="schedulePickup"
+            ariaLabel="Select a pickup event"
+            options={events.map((e, index) => {
+              return {
+                value: index.toString(),
+                label: `${e.title} (${formatEventDate(e.start, e.end)})`,
+              };
+            })}
+            value={eventIndex.toString()}
+            onChange={v => setEventIndex(Number(v))}
+          />
+        </div>
+      ) : (
+        <div className={styles.noEvents}>
+          <Typography variant="h3/medium" component="span">
+            No upcoming pickup events. Check back later!
+          </Typography>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PickupEventDropdown;

--- a/src/components/store/PickupEventDropdown/style.module.scss
+++ b/src/components/store/PickupEventDropdown/style.module.scss
@@ -1,0 +1,42 @@
+@use 'src/styles/vars.scss' as vars;
+
+.eventPicker {
+  display: flex;
+  flex-direction: column;
+  min-height: 400px;
+
+  .window {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    height: 100%;
+    padding: 2rem;
+
+    .dropdown {
+      background-color: var(--theme-surface-1);
+      border-radius: 1rem;
+      line-height: 2rem;
+      padding: 1rem;
+
+      select {
+        font-weight: normal;
+      }
+
+      option,
+      button,
+      div {
+        background-color: var(--theme-surface-1);
+
+        :hover {
+          background-color: var(--theme-surface-2);
+        }
+      }
+    }
+  }
+
+  .noEvents {
+    color: var(--theme-text-on-background-3);
+    margin: auto;
+    text-align: center;
+  }
+}

--- a/src/components/store/PickupEventDropdown/style.module.scss
+++ b/src/components/store/PickupEventDropdown/style.module.scss
@@ -3,7 +3,6 @@
 .eventPicker {
   display: flex;
   flex-direction: column;
-  min-height: 400px;
 
   .window {
     display: flex;

--- a/src/components/store/PickupEventDropdown/style.module.scss.d.ts
+++ b/src/components/store/PickupEventDropdown/style.module.scss.d.ts
@@ -1,0 +1,12 @@
+export type Styles = {
+  dropdown: string;
+  eventPicker: string;
+  noEvents: string;
+  window: string;
+};
+
+export type ClassNames = keyof Styles;
+
+declare const styles: Styles;
+
+export default styles;

--- a/src/components/store/index.ts
+++ b/src/components/store/index.ts
@@ -13,6 +13,7 @@ export { default as OrderCard } from './OrderCard';
 export { default as OrdersDisplay } from './OrdersDisplay';
 export { default as PickupEventDetail } from './PickupEventDetail';
 export { default as PickupEventPicker } from './PickupEventPicker';
+export { default as PickupEventDropdown } from './PickupEventDropdown';
 export { default as StoreConfirmModal } from './StoreConfirmModal';
 export { default as StoreEditButton } from './StoreEditButton';
 export { default as Navbar } from './StoreNavbar';

--- a/src/pages/store/cart.tsx
+++ b/src/pages/store/cart.tsx
@@ -4,6 +4,7 @@ import {
   Diamonds,
   Navbar,
   PickupEventDetail,
+  PickupEventDropdown,
   PickupEventPicker,
   StoreConfirmModal,
 } from '@/components/store';
@@ -186,12 +187,21 @@ const StoreCartPage = ({ user: { credits }, savedCart, pickupEvents }: CartPageP
                 {cartState !== CartState.CONFIRMED ? 'Choose Pickup Event' : 'Pickup Event Details'}
               </Typography>
             </div>
-            <PickupEventPicker
-              events={pickupEvents}
-              eventIndex={pickupIndex}
-              setEventIndex={setPickupIndex}
-              active={cartState !== CartState.CONFIRMED}
-            />
+            <div className={styles.mobile}>
+              <PickupEventPicker
+                events={pickupEvents}
+                eventIndex={pickupIndex}
+                setEventIndex={setPickupIndex}
+                active={cartState !== CartState.CONFIRMED}
+              />
+            </div>
+            <div className={styles.desktop}>
+              <PickupEventDropdown
+                events={pickupEvents}
+                eventIndex={pickupIndex}
+                setEventIndex={setPickupIndex}
+              />
+            </div>
           </div>
         )}
 

--- a/src/styles/pages/store/cart/index.module.scss
+++ b/src/styles/pages/store/cart/index.module.scss
@@ -8,27 +8,26 @@
   max-width: 81rem;
 
   .content {
-    align-items: start;
     display: grid;
     grid-column-gap: 2rem;
     grid-template-areas:
-      'title placeOrder'
-      'confirmation event'
-      'items event'
+      'title title'
+      'confirmation confirmation'
       'items summary'
-      'items warning';
+      'event placeOrder'
+      'warning placeOrder';
     grid-template-columns: 1fr 20rem;
     grid-template-rows: auto auto auto auto 1fr;
 
     @media screen and (max-width: vars.$breakpoint-md) {
       grid-template-areas:
         'title'
-        'placeOrder'
         'warning'
         'confirmation'
         'event'
         'items'
-        'summary';
+        'summary'
+        'placeOrder';
       grid-template-columns: 1fr;
     }
 
@@ -165,8 +164,26 @@
     }
 
     .eventPicker {
+      background-color: var(--theme-elevated-background);
       grid-area: event;
       margin-bottom: 2rem;
+      overflow: visible;
+
+      .mobile {
+        display: none;
+
+        @media screen and (max-width: vars.$breakpoint-md) {
+          display: block;
+        }
+      }
+
+      .desktop {
+        display: block;
+
+        @media screen and (max-width: vars.$breakpoint-md) {
+          display: none;
+        }
+      }
     }
 
     .warning {

--- a/src/styles/pages/store/cart/index.module.scss
+++ b/src/styles/pages/store/cart/index.module.scss
@@ -167,7 +167,10 @@
       background-color: var(--theme-elevated-background);
       grid-area: event;
       margin-bottom: 2rem;
-      overflow: visible;
+
+      @media screen and (min-width: vars.$breakpoint-md) {
+        overflow: visible;
+      }
 
       .mobile {
         display: none;

--- a/src/styles/pages/store/cart/index.module.scss.d.ts
+++ b/src/styles/pages/store/cart/index.module.scss.d.ts
@@ -4,10 +4,12 @@ export type Styles = {
   confirming: string;
   container: string;
   content: string;
+  desktop: string;
   emptyCart: string;
   eventPicker: string;
   header: string;
   items: string;
+  mobile: string;
   pickupEventDetail: string;
   placeOrder: string;
   points: string;


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

Closes #243

<!-- If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak. -->

Restructured store layout and added dropdown component for desktop view

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

## Changes

- Reordered store checkout layout for mobile/desktop
- Added dropdown component similar to reschedule event modal for desktop view
- Kept original pickup event picker for mobile view

# Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->
<img width="234" alt="Screenshot 2024-08-12 at 10 39 27 PM" src="https://github.com/user-attachments/assets/a217d24f-be6f-483e-9db5-ab39dcb8e5c8">
<img width="1032" alt="Screenshot 2024-08-12 at 10 34 58 PM" src="https://github.com/user-attachments/assets/9db0dea2-3763-4a45-a881-c225dcac0955">
<img width="974" alt="Screenshot 2024-08-12 at 10 35 39 PM" src="https://github.com/user-attachments/assets/b6680ba3-7514-49c9-b046-0642ab1b6864">