### PR TITLE
Use Pacific Time on server side

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -183,19 +183,22 @@ export function useObjectUrl(file?: Blob | null): string {
   return url;
 }
 
+// Set timeZone to Pacific Time on server-side, use local time on client. Users
+// will usually be in California, so this helps with hydration.
 const dateFormat = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
   hour: 'numeric',
   minute: '2-digit',
+  timeZone: typeof window === 'undefined' ? 'America/Los_Angeles' : undefined,
 });
-
 const dateFormatWithYear = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
   hour: 'numeric',
   minute: '2-digit',
+  timeZone: typeof window === 'undefined' ? 'America/Los_Angeles' : undefined,
 });
 
 export const formatDate = (date: Date | string, year?: boolean): string => {


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info


<!-- If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak. -->

![image](https://github.com/user-attachments/assets/cc99bde0-0726-410c-a132-7e123eb41504)

4 am?? oops

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

Uses Pacific Time when displaying dates on server side only. The client continues to use local time.

## Changes

It seems the Vercel servers are in a different time zone (maybe UTC?), so when displaying dates on the server side, I changed it to use the America/Los_Angeles time zone. This fixes the times rendered in event web previews. The client uses local time, like before.

An alternative option would be to force Pacific Time on the client. This could make sense since ACM at UCSD is based in California. However, we still host online events like Leetcode sessions, and people might be attending them from outside of California, so it would be helpful to continue showing them the event's time in their time zone.

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->


![image](https://github.com/user-attachments/assets/8d427d4d-093a-46ff-b095-55252f9f94e8)

the event image says october 2 but i don't think that's my fault